### PR TITLE
Fix and simplify version display

### DIFF
--- a/src/constants/version.cpp.in
+++ b/src/constants/version.cpp.in
@@ -1,11 +1,8 @@
 #include "constants/version.hpp"
-#include "constants/proto.hpp"
 
 namespace srouter
 {
-  // clang-format off
-  const std::array<uint8_t, 3> SROUTER_VERSION{{@session-router_VERSION_MAJOR@, @session-router_VERSION_MINOR@, @session-router_VERSION_PATCH@}};
-  const char* const SROUTER_VERSION_TAG   = "@VERSIONTAG@";
-  const char* const SROUTER_VERSION_FULL  = "session-router-@session-router_VERSION_MAJOR@.@session-router_VERSION_MINOR@.@session-router_VERSION_PATCH@-@VERSIONTAG@";
-  // clang-format on
+    const std::array<uint8_t, 3> VERSION{{@session-router_VERSION_MAJOR@, @session-router_VERSION_MINOR@, @session-router_VERSION_PATCH@}};
+    const std::string VERSION_TAG{"@VERSIONTAG@"};
+    const std::string VERSION_FULL{"session-router-@session-router_VERSION_MAJOR@.@session-router_VERSION_MINOR@.@session-router_VERSION_PATCH@-@VERSIONTAG@"};
 }  // namespace srouter

--- a/src/constants/version.hpp
+++ b/src/constants/version.hpp
@@ -2,11 +2,12 @@
 
 #include <array>
 #include <cstdint>
+#include <string>
 
 namespace srouter
 {
     // Given a full Session Router version of: session-router-1.2.3-abc these are:
-    extern const std::array<uint8_t, 3> SROUTER_VERSION;  // [1, 2, 3]
-    extern const char* const SROUTER_VERSION_TAG;         // "abc"
-    extern const char* const SROUTER_VERSION_FULL;        // "session-router-1.2.3-abc"
+    extern const std::array<uint8_t, 3> VERSION;  // [1, 2, 3]
+    extern const std::string VERSION_TAG;         // "abc"
+    extern const std::string VERSION_FULL;        // "session-router-1.2.3-abc"
 }  // namespace srouter

--- a/src/contact/relay_contact.cpp
+++ b/src/contact/relay_contact.cpp
@@ -189,7 +189,7 @@ namespace srouter
           _addr{router.public_addr()},
           _timestamp{std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now())},
           _netid{router.netid()},
-          _router_version{srouter::SROUTER_VERSION}
+          _router_version{srouter::VERSION}
     {
         oxenc::bt_dict_producer btdp;
         if (VERSION != 0)
@@ -229,7 +229,7 @@ namespace srouter
 
         btdp.append("t", _timestamp.time_since_epoch().count());
 
-        static_assert(srouter::SROUTER_VERSION.size() == 3);
+        static_assert(srouter::VERSION.size() == 3);
         btdp.append("v", std::span{_router_version});
 
         btdp.append_signature("~", [&router](std::span<const std::byte> to_sign) {

--- a/src/daemon/session_router.cpp
+++ b/src/daemon/session_router.cpp
@@ -369,7 +369,7 @@ namespace
         {
             if (options.version)
             {
-                std::cout << srouter::SROUTER_VERSION_FULL << std::endl;
+                std::cout << srouter::VERSION_FULL << std::endl;
                 return 0;
             }
 
@@ -500,7 +500,7 @@ namespace
     // this sets up, configures and runs the main context
     void start_srouter(std::optional<std::filesystem::path> confFile, bool snode)
     {
-        srouter::log::info(logcat, "starting up {}", srouter::SROUTER_VERSION_FULL);
+        srouter::log::info(logcat, "starting up {}", srouter::VERSION_FULL);
         try
         {
             auto type = snode ? srouter::config::Type::Relay : srouter::config::Type::FullClient;

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -200,7 +200,8 @@ namespace srouter
 
         nlohmann::json stats{
             {"running", true},
-            {"version", srouter::SROUTER_VERSION_FULL},
+            {"version", srouter::VERSION},
+            {"version_full", srouter::VERSION_FULL},
             {"uptime", to_json(Uptime())},
             // {"numPathsBuilt", pathsCount},
             // {"numPeersConnected", peers},
@@ -818,7 +819,7 @@ namespace srouter
     {
         auto now = srouter::time_now_ms();
         return "v{} {}: {}"_format(
-            srouter::SROUTER_VERSION_FULL, is_service_node ? "relay" : "client", _stats_line(now));
+            fmt::join(srouter::VERSION, "."), is_service_node ? "relay" : "client", _stats_line(now));
     }
 
     void Router::_relay_tick([[maybe_unused]] std::chrono::milliseconds now)

--- a/src/rpc/oxend_rpc.cpp
+++ b/src/rpc/oxend_rpc.cpp
@@ -146,8 +146,7 @@ namespace srouter::rpc
         auto pk = _router.id();
 
         nlohmann::json payload = {
-            {"pubkey_ed25519", oxenc::to_hex(pk.begin(), pk.end())},
-            {"version", {SROUTER_VERSION[0], SROUTER_VERSION[1], SROUTER_VERSION[2]}}};
+            {"pubkey_ed25519", oxenc::to_hex(pk.begin(), pk.end())}, {"version", srouter::VERSION}};
 
         if (auto err = _router.OxendErrorState())
             payload["error"] = *err;

--- a/src/rpc/rpc_server.cpp
+++ b/src/rpc/rpc_server.cpp
@@ -135,7 +135,10 @@ namespace srouter::rpc
     {
         log_print_rpc(version);
 
-        nlohmann::json result{{"version", srouter::SROUTER_VERSION_FULL}, {"uptime", to_json(_router.Uptime())}};
+        nlohmann::json result{
+            {"version", srouter::VERSION},
+            {"version_full", srouter::VERSION_FULL},
+            {"uptime", to_json(_router.Uptime())}};
 
         SetJSONResponse(result, version.response);
     }


### PR DESCRIPTION
This fixes/simplifies a few things with the version variable:
- the version display in the systemd Status line now only shows the version, not the verbose full string
- Renames variables from SROUTER_VERSION* to just VERSION*, since they are already in the `srouter` namespace.
- Makes them C++ strings instead of C strings.
- Expose the version array via json responses along with the full version, instead of just the verbose stringified, so that json consumers can use it without needing to try to parse it back out of a non-trivial string.