### PR TITLE
Improve new Session Router relay onboarding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 
 project(session-router
-    VERSION 1.0.0
+    VERSION 1.0.1
     DESCRIPTION "Session Router - IP packet onion router"
     LANGUAGES ${LANGS})
 

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -724,8 +724,15 @@ namespace srouter
     {
         // If we're in the registered list then we *should* be establishing connections to other
         // routers, so if we have almost no peers then something is almost certainly wrong.
+        //
+        // FIXME - this is disabled during Session Router optional transition so that new nodes that
+        // can't yet connect to other network nodes don't prevent oxend from sending proofs.
+        // TODO: uncomment this again once Session Router is mandatory (and the mandatory HF is live
+        // on the network).
+        /*
         if (insufficient_peers() and not _config.oxend.disable_testing)
             return "too few peer connections; Session Router is not adequately connected to the network";
+        */
         return std::nullopt;
     }
 

--- a/src/rpc/oxend_rpc.cpp
+++ b/src/rpc/oxend_rpc.cpp
@@ -81,7 +81,7 @@ namespace srouter::rpc
             return;               // update already in progress
         }
 
-        nlohmann::json req{{"fields", {"pubkey_ed25519", "block_hash", "session_router_version"}}};
+        nlohmann::json req{{"fields", {"pubkey_ed25519", "block_hash", "service_node_version"}}};
         if (!_last_hash_update.empty())
             req["poll_block_hash"] = _last_hash_update;
 
@@ -204,16 +204,19 @@ namespace srouter::rpc
             }
 
             // Transition mechanism for Oxen 11.6 where Session Router is not yet required for
-            // service nodes: we only consider a node registered if has reported a
-            // session_router_version.
+            // service nodes: we only consider a node registered for Session Router purposes if has
+            // send a 11.6+ uptime proof.
             //
             // TODO: remove this once we are past the session-router-is-required-now oxend mandatory
             // upgrade.
-            auto srv_it = snode.find("session_router_version");
-            if (srv_it == snode.end() || srv_it->get<std::array<int, 3>>() < std::array{1, 0, 0})
+            //
+            // TODO 2: also remove the don't-report-error-state code in router/router.cpp
+            // (Router::OxendErrorState) once we are past that upgrade.
+            auto srv_it = snode.find("service_node_version");
+            if (srv_it == snode.end() || srv_it->get<std::array<int, 3>>() < std::array{11, 6, 0})
             {
                 log::debug(
-                    logcat, "Ignoring {} registration: uptime proof does not include a Session Router version", rid);
+                    logcat, "Ignoring {} registration: uptime proof version does not require Session Router", rid);
                 continue;
             }
 


### PR DESCRIPTION
If an upgrade happens right now it seems possible that Session Router and oxend could end up in a weird state where Session Router can't connect to anyone (because oxend hasn't sent a proof indicating session router support), and oxend won't send a proof because Session Router is reporting too-few-peers to oxend.

This *isn't* always happening, however (lots of nodes have upgraded without getting stuck), but seems at least one person has got stuck in such a situation.

This disables the oxend error state reporting entirely as a temporary measure to avoid this, so that oxend can send the proof out.

Secondly this solves a related issue where newly installed Session Nodes that know about other nodes 11.6.0 upgrade *don't* know about the session_router_version because they received the proof while running 11.5.0.  Because 11.5 knew nothing about the SR field in the proof (and just ignored it) it just ends up with a defaulted 0.0.0 for any proofs it received before upgrading.  That, in turn, causes SR to think the node isn't running SR yet, even though it is.  This fixes it by looking for oxend version >= 11.6.0 instead, because even unupgraded nodes *will* have stored that, even if they didn't understand the SR version inside the proof.