### PR TITLE
Disconnect from deregged SNs after a delay

### DIFF
--- a/src/link/connection.cpp
+++ b/src/link/connection.cpp
@@ -10,10 +10,9 @@ namespace srouter::link
         : conn{std::move(c)}, datagrams{conn->datagrams()}, control_stream{std::move(s)}
     {}
 
-    void Connection::close_quietly()
+    void Connection::close(uint64_t errcode)
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
-        conn->set_close_quietly();
-        conn->close_connection();
+        conn->close_connection(errcode);
     }
 }  // namespace srouter::link

--- a/src/link/connection.hpp
+++ b/src/link/connection.hpp
@@ -24,6 +24,6 @@ namespace srouter::link
 
         bool is_inbound() const { return conn->is_inbound(); }
 
-        void close_quietly();
+        void close(uint64_t errcode = 0);
     };
 }  // namespace srouter::link

--- a/src/link/endpoint.cpp
+++ b/src/link/endpoint.cpp
@@ -20,20 +20,20 @@ namespace srouter::link
     {
         auto& ptr = is_inbound ? inbound : outbound;
         if (ptr)
-            ptr->close_quietly();
+            ptr->close();
         ptr = std::move(c);
 
         if (is_inbound ? not outbound or inbound_wins : not inbound or not inbound_wins)
             conn = ptr.get();
     }
 
-    void relay_conn::close_quietly(bool direction_inbound)
+    void relay_conn::close(bool direction_inbound, uint64_t errcode)
     {
         auto& to_close = direction_inbound ? inbound : outbound;
         if (not to_close)
             return;
 
-        to_close->close_quietly();
+        to_close->close(errcode);
         to_close.reset();
 
         // Switch preferred conn to the other direction (will be nullptr if the other direction
@@ -41,17 +41,17 @@ namespace srouter::link
         conn = (direction_inbound ? outbound : inbound).get();
     }
 
-    void relay_conn::close_all_quietly()
+    void relay_conn::close_all(uint64_t errcode)
     {
         if (inbound)
-            inbound->close_quietly();
+            inbound->close(errcode);
         if (outbound)
-            outbound->close_quietly();
+            outbound->close(errcode);
         inbound = outbound = nullptr;
         conn = nullptr;
     }
 
-    void relay_conn::close_redundant() { close_quietly(not inbound_wins); }
+    void relay_conn::close_redundant() { close(not inbound_wins, CONN_CLOSE_REDUNDANT); }
 
     static std::vector<uint8_t> make_static_secret(
         const Ed25519SecretKey& sk, std::string_view static_secret_key = "Session Router static shared secret key"sv)
@@ -240,7 +240,9 @@ namespace srouter::link
         {
             const auto& [rid, dead_since] = *it;
 
-            if (dead_since + DEREGGED_LINGER > now)
+            // -1s because this only fires every 1min and the -1s prevents tiny variations in the
+            // clock from "missing" the threshold and pushing to 31min instead of 30min.
+            if (dead_since + DEREGGED_LINGER > now - 1s)
             {
                 // Not dead long enough
                 ++it;
@@ -250,14 +252,21 @@ namespace srouter::link
             if (registered.contains(rid))
             {
                 // Became registered again somehow
-                log::debug(logcat, "Not disconnecting from previously de-regged node {}: it is registered again", rid);
+                log::debug(logcat, "Not disconnecting from previously de-regged {}.snode: it is registered again", rid);
                 it = pending_dead.erase(it);
                 continue;
             }
 
-            if (relay_conns.erase(rid))
+            if (auto rcit = relay_conns.find(rid); rcit != relay_conns.end())
             {
-                pending_outbound.erase(rid);
+                rcit->second.close_all();
+                relay_conns.erase(rcit);
+                if (auto pit = pending_outbound.find(rid); pit != pending_outbound.end())
+                {
+                    if (pit->second)
+                        pit->second->close();
+                    pending_outbound.erase(pit);
+                }
                 relay_bidir.erase(rid);
                 log::debug(logcat, "Dropped connection to deregistered node {}", rid);
             }
@@ -267,7 +276,8 @@ namespace srouter::link
             it = pending_dead.erase(it);
         }
 
-        // Record timestamps for any newly unregistered nodes
+        // Record timestamps for any newly unregistered nodes so that, when the timer expires, we
+        // drop the connection.
         for (const auto& [rid, rconn] : relay_conns)
             if (!registered.contains(rid) && pending_dead.emplace(rid, now).second)
                 log::debug(
@@ -367,20 +377,20 @@ namespace srouter::link
     {
         log::debug(logcat, "Closing all connections");
         for (auto& [rid, conn] : relay_conns)
-            conn.close_all_quietly();
+            conn.close_all();
         relay_conns.clear();
         relay_bidir.clear();
 
         for (auto& conn : pending_outbound | std::views::values)
-            conn->close_quietly();
+            conn->close();
         pending_outbound.clear();
 
         for (auto& conn : client_conns | std::views::values)
-            conn->close_quietly();
+            conn->close();
         client_conns.clear();
 
         for (auto& conn : inbound_clients | std::views::values)
-            conn->close_quietly();
+            conn->close();
         inbound_clients.clear();
 
         log::debug(logcat, "Closing quic endpoint");
@@ -742,7 +752,7 @@ namespace srouter::link
             {
                 log::error(
                     logcat, "Internal error: duplicate outbound connection established, but that shouldn't happen");
-                cc->close_quietly();
+                cc->close();
             }
             cc = std::move(pit->second);
             log::debug(
@@ -825,14 +835,14 @@ namespace srouter::link
                     auto& relcon = it->second;
                     if (relcon.inbound && connptr == relcon.inbound->conn)
                     {
-                        relcon.close_quietly(true);
+                        relcon.close(true);
                         found = true;
                         log::debug(
                             logcat, "Inbound connection from {} closed (ec={})", rid->to_network_address(true), ec);
                     }
                     if (relcon.outbound && connptr == relcon.outbound->conn)
                     {
-                        relcon.close_quietly(false);
+                        relcon.close(false);
                         found = true;
                         log::debug(
                             logcat, "Outbound connection to {} closed (ec={})", rid->to_network_address(true), ec);
@@ -859,6 +869,18 @@ namespace srouter::link
                     pending_outbound.erase(it);
                     found = true;
                 }
+
+                if (!found && ec == CONN_CLOSE_REDUNDANT)
+                {
+                    log::debug(
+                        logcat,
+                        "Closed redundant connection {} {} @ {} (cid={})",
+                        conn.is_inbound() ? "from" : "to",
+                        rid->to_network_address(true),
+                        conn.remote(),
+                        conn.reference_id());
+                    found = true;
+                }
             }
             else if (alpn == CLIENT_ALPN)
             {
@@ -869,7 +891,7 @@ namespace srouter::link
                     if (auto it = inbound_clients.find(conn.reference_id()); it != inbound_clients.end())
                     {
                         log::debug(logcat, "Client connection from {} closed (ec={})", conn.remote(), ec);
-                        it->second->close_quietly();
+                        it->second->close();
                         inbound_clients.erase(it);
                         found = true;
                     }
@@ -908,9 +930,9 @@ namespace srouter::link
             if (!found)
                 log::warning(
                     logcat,
-                    "Closed untracked connection {} {} @ {} (cid={}, ec={})",
+                    "Closed connection {} {} @ {} (cid={}, ec={})",
                     conn.is_inbound() ? "from" : "to",
-                    rid ? rid->to_network_address(true /* don't know! */).to_string() : "",
+                    rid ? rid->to_string() : "",
                     conn.remote(),
                     conn.reference_id(),
                     ec);

--- a/src/link/endpoint.cpp
+++ b/src/link/endpoint.cpp
@@ -10,6 +10,8 @@
 #include <oxen/quic/opt.hpp>
 #include <sodium/crypto_generichash_blake2b.h>
 
+#include <chrono>
+
 namespace srouter::link
 {
     static auto logcat = log::Cat("link.endpoint");
@@ -186,7 +188,10 @@ namespace srouter::link
     void Endpoint::start_tickers()
     {
         if (router.is_service_node)
+        {
             redundancy_ticker = router.loop.call_every(REDUNDANT_LINGER, [this] { close_redundant(); });
+            dereg_conn_ticker = router.loop.call_every(1min, [this] { check_deregged_conns(); });
+        }
     }
 
     link::Connection* Endpoint::get_relay_conn(const RouterID& relay) const
@@ -220,6 +225,53 @@ namespace srouter::link
             else
                 ++it;
         }
+    }
+
+    void Endpoint::check_deregged_conns()
+    {
+        assert(router.is_service_node);
+
+        auto now = std::chrono::steady_clock::now();
+
+        auto registered = router.node_db().get_registered_relay_set();
+
+        // Look for any pending dead that have been dead long enough to disconnect from:
+        for (auto it = pending_dead.begin(); it != pending_dead.end();)
+        {
+            const auto& [rid, dead_since] = *it;
+
+            if (dead_since + DEREGGED_LINGER > now)
+            {
+                // Not dead long enough
+                ++it;
+                continue;
+            }
+
+            if (registered.contains(rid))
+            {
+                // Became registered again somehow
+                log::debug(logcat, "Not disconnecting from previously de-regged node {}: it is registered again", rid);
+                it = pending_dead.erase(it);
+                continue;
+            }
+
+            if (relay_conns.erase(rid))
+            {
+                pending_outbound.erase(rid);
+                relay_bidir.erase(rid);
+                log::debug(logcat, "Dropped connection to deregistered node {}", rid);
+            }
+            else
+                log::debug(logcat, "Connection to deregged node {} is already dropped", rid);
+
+            it = pending_dead.erase(it);
+        }
+
+        // Record timestamps for any newly unregistered nodes
+        for (const auto& [rid, rconn] : relay_conns)
+            if (!registered.contains(rid) && pending_dead.emplace(rid, now).second)
+                log::debug(
+                    logcat, "Relay {} is no longer registered; scheduling disconnect in {}", rid, DEREGGED_LINGER);
     }
 
     link::Connection* Endpoint::get_client_conn(const RouterID& remote) const

--- a/src/link/endpoint.hpp
+++ b/src/link/endpoint.hpp
@@ -39,6 +39,8 @@ namespace srouter::link
     // longer than the longest path to allow those clients to naturally migrate to new paths.
     inline constexpr auto DEREGGED_LINGER = 30min;
 
+    static constexpr uint64_t CONN_CLOSE_REDUNDANT = 6;
+
     // Stores relay-to-relay connections.  In order to not lose stream messages, we temporarily
     // allow simultaneous connections in both directions between a pair of relays, but then
     // after a timeout, both sides choose the same winner and drop the other one.  The timeout
@@ -67,10 +69,10 @@ namespace srouter::link
         // Closes either the inbound or outbound connection and drops it from this instance.  If
         // the other connection still exists then `conn` is updated to point at it, otherwise it
         // is set to nullptr.  Does nothing if the indicated connection is already closed.
-        void close_quietly(bool direction_inbound);
+        void close(bool direction_inbound, uint64_t errcode = 0);
 
         // Closes all connections, in both directions (if opened).
-        void close_all_quietly();
+        void close_all(uint64_t errcode = 0);
 
         // Closes the "loser" connection, if this instance has connections in both directions.
         void close_redundant();

--- a/src/link/endpoint.hpp
+++ b/src/link/endpoint.hpp
@@ -33,6 +33,12 @@ namespace srouter::link
     // twice this value.
     inline constexpr auto REDUNDANT_LINGER = 20s;
 
+    // How long we leave router connections open to session routers that are no longer on the
+    // network (i.e. left gracefully or were deregistered).  We don't kill these connections
+    // immediately as they may still be in use by existing clients paths, so we keep them alive for
+    // longer than the longest path to allow those clients to naturally migrate to new paths.
+    inline constexpr auto DEREGGED_LINGER = 30min;
+
     // Stores relay-to-relay connections.  In order to not lose stream messages, we temporarily
     // allow simultaneous connections in both directions between a pair of relays, but then
     // after a timeout, both sides choose the same winner and drop the other one.  The timeout
@@ -93,6 +99,11 @@ namespace srouter::link
         // `relay_conns` (relays).
         std::unordered_map<RouterID, std::shared_ptr<link::Connection>> pending_outbound;
 
+        // Stores any "dead" router IDs (i.e. unlocked or deregged) that we have connections with,
+        // along with the timestamp of when we first noticed they were no longer valid.  Once we
+        // reach DEREGGED_LINGER, we close the connection.
+        std::unordered_map<RouterID, std::chrono::steady_clock::time_point> pending_dead;
+
         // Stores established client-to-relay connections (i.e. outbound edge connections).  Client
         // only.
         std::unordered_map<RouterID, std::shared_ptr<link::Connection>> client_conns;
@@ -104,6 +115,7 @@ namespace srouter::link
         std::unique_ptr<quic::Loop> loop;
         std::shared_ptr<quic::Endpoint> endpoint;
         std::shared_ptr<quic::Ticker> redundancy_ticker;
+        std::shared_ptr<quic::Ticker> dereg_conn_ticker;
         std::shared_ptr<quic::GNUTLSCreds> tls_creds;
 
       public:
@@ -118,6 +130,12 @@ namespace srouter::link
         // established in both directions and sufficient time has passed so ensure that all messages
         // are flowing on the mutually preferred connection.
         void close_redundant(sys_ms now = srouter::time_now_ms());
+
+        // Checks for any existing connections to expired nodes and, after a delay, closes them.
+        // (They delay is to give time for clients still using a path through us to the deregged
+        // node to build and switch to new paths).  This runs infrequently (once/minute) because
+        // leaving the connections around for a little longer doesn't hurt anything.
+        void check_deregged_conns();
 
         // Returns an established client->relay connection, if one exists.  Client only.  Returns
         // nullptr if there is no current established connection to the given relay.

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -752,6 +752,14 @@ namespace srouter
         std::shared_lock lock{_registered_relays_mutex};
         result.reserve(_registered_relays.size());
         result.assign(_registered_relays.begin(), _registered_relays.end());
+
+        return result;
+    }
+
+    std::unordered_set<RouterID> NodeDB::get_registered_relay_set() const
+    {
+        std::shared_lock lock{_registered_relays_mutex};
+        std::unordered_set<RouterID> result{_registered_relays};
         return result;
     }
 

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -163,6 +163,7 @@ namespace srouter
         void set_registered_relays(std::unordered_set<RouterID> relays);
         bool has_registered_relays() const;
         std::vector<RouterID> get_registered_relays() const;
+        std::unordered_set<RouterID> get_registered_relay_set() const;
 
         // Called if our initial oxend SN request fails to load the router IDs of any RCs in our
         // nodedb as our initial registered relay list until some future oxend update comes along to


### PR DESCRIPTION
When a node leaves the network, currently we just keep an established connection to that node alive as long as it stays up.

This fixes that by adding a check for deregged nodes and, if found, disconnects them after half an hour.

The delay here is to attempt to not kill existing client paths that may still be using a path through us to the deregged node, allowing some time for the client to replace the path with new paths that don't use it.