### PR TITLE
Change client RC fetch/update mechanism

### DIFF
--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -307,27 +307,29 @@ namespace srouter::link
         try
         {
             oxenc::bt_dict_producer btdp;
-            auto btlp = btdp.append_list("r"sv);
-
-            auto btdc = oxenc::bt_dict_consumer{body};
-            auto arg_buckets = btdc.require<oxenc::bt_list_consumer>("b"sv);
-            RCHash h;
-            for (uint8_t i = 0; i < 128; i++)
             {
-                auto h_span = arg_buckets.consume_span<std::byte, 8>();
-                std::memcpy(h.data(), h_span.data(), 8);
-                if (rc_buckets[i] != h)
+                auto btlp = btdp.append_list("r"sv);
+
+                auto btdc = oxenc::bt_dict_consumer{body};
+                auto arg_buckets = btdc.require<oxenc::bt_list_consumer>("b"sv);
+                RCHash h;
+                for (uint8_t i = 0; i < 128; i++)
                 {
-                    for (const auto& [rid, _] : rc_hashes[i])
+                    auto h_span = arg_buckets.consume_span<std::byte, 8>();
+                    std::memcpy(h.data(), h_span.data(), 8);
+                    if (rc_buckets[i] != h)
                     {
-                        if (auto* maybe_rc = router.node_db().get_rc(rid))
-                            btlp.append(maybe_rc->view());
-                        else
-                            log::critical(logcat, "Somehow we have a bucket hash for {} but no RC!", rid);
+                        for (const auto& [rid, _] : rc_hashes[i])
+                        {
+                            if (auto* maybe_rc = router.node_db().get_rc(rid))
+                                btlp.append(maybe_rc->view());
+                            else
+                                log::critical(logcat, "Somehow we have a bucket hash for {} but no RC!", rid);
+                        }
                     }
                 }
+                arg_buckets.finish();
             }
-            arg_buckets.finish();
 
             respond(std::move(btdp).str());
         }

--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -306,19 +306,17 @@ namespace srouter::link
 
         try
         {
-            auto btdc = oxenc::bt_dict_consumer{body};
-            auto arg_buckets = btdc.require<std::vector<uint64_t>>("b"sv);
-            if (arg_buckets.size() != 128)
-                throw std::runtime_error{fmt::format(
-                    "RC fetch request provided wrong number {} of bucket hashes, expected {}",
-                    arg_buckets.size(),
-                    128)};
-
             oxenc::bt_dict_producer btdp;
-            auto btlp = btdp.append_list("r");
+            auto btlp = btdp.append_list("r"sv);
+
+            auto btdc = oxenc::bt_dict_consumer{body};
+            auto arg_buckets = btdc.require<oxenc::bt_list_consumer>("b"sv);
+            RCHash h;
             for (uint8_t i = 0; i < 128; i++)
             {
-                if (rc_buckets[i] != arg_buckets[i])
+                auto h_span = arg_buckets.consume_span<std::byte, 8>();
+                std::memcpy(h.data(), h_span.data(), 8);
+                if (rc_buckets[i] != h)
                 {
                     for (const auto& [rid, _] : rc_hashes[i])
                     {
@@ -329,6 +327,8 @@ namespace srouter::link
                     }
                 }
             }
+            arg_buckets.finish();
+
             respond(std::move(btdp).str());
         }
         catch (const std::exception& e)

--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -301,38 +301,41 @@ namespace srouter::link
         // this handler should not be registered for clients
         assert(router.is_service_node);
 
-        std::unordered_set<RouterID> explicit_ids;
+        const auto& rc_hashes = router.node_db().get_rc_hashes();
+        const auto& rc_buckets = router.node_db().get_rc_buckets();
 
         try
         {
             auto btdc = oxenc::bt_dict_consumer{body};
-            for (auto sublist = btdc.require<oxenc::bt_list_consumer>("x"); !sublist.is_finished();)
-                explicit_ids.emplace(sublist.consume_span<uint8_t, 32>());
+            auto arg_buckets = btdc.require<std::vector<uint64_t>>("b"sv);
+            if (arg_buckets.size() != 128)
+                throw std::runtime_error{fmt::format(
+                    "RC fetch request provided wrong number {} of bucket hashes, expected {}",
+                    arg_buckets.size(),
+                    128)};
+
+            oxenc::bt_dict_producer btdp;
+            auto btlp = btdp.append_list("r");
+            for (uint8_t i = 0; i < 128; i++)
+            {
+                if (rc_buckets[i] != arg_buckets[i])
+                {
+                    for (const auto& [rid, _] : rc_hashes[i])
+                    {
+                        if (auto* maybe_rc = router.node_db().get_rc(rid))
+                            btlp.append(maybe_rc->view());
+                        else
+                            log::critical(logcat, "Somehow we have a bucket hash for {} but no RC!", rid);
+                    }
+                }
+            }
+            respond(std::move(btdp).str());
         }
         catch (const std::exception& e)
         {
             log::warning(logcat, "Exception handling RC Fetch request: {}", e.what());
             respond(messages::ERROR_RESPONSE);
-            return;
         }
-
-        oxenc::bt_dict_producer btdp;
-        {
-            auto sublist = btdp.append_list("r");
-
-            int count = 0;
-            for (const auto& rid : explicit_ids)
-            {
-                if (auto* maybe_rc = router.node_db().get_rc(rid))
-                {
-                    sublist.append_encoded(maybe_rc->view());
-                    ++count;
-                }
-            }
-            log::info(logcat, "Returning {} RCs for FetchRC request...", count);
-        }
-
-        respond(std::move(btdp).str());
     }
 
     void Manager::handle_path_fetch_rcs(std::span<const std::byte> body, std::function<void(std::string)> respond)

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -84,7 +84,6 @@ namespace srouter
         // hash everything up to the literal byte "t" of the key (the key is "1:t")
         auto time_key_and_data = btdc.next_integer<uint64_t>();
         size_t to_hash = time_key_and_data.first.data() - serialized_rc.data();
-        btdc.consume_integer<uint64_t>();
         crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(serialized_rc.data()), to_hash);
 
         // hash everything starting from the beginning of the next key to the end

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -69,9 +69,9 @@ namespace srouter
     // 64-bits is large enough, as we don't need to worry about collisions
     //
     // Throws if key "t" is not found (or if somehow the input is not a valid bt-dict)
-    static uint64_t bucket_hash(std::string_view serialized_rc)
+    static RCHash bucket_hash(std::string_view serialized_rc)
     {
-        uint64_t ret;
+        RCHash ret;
 
         crypto_generichash_blake2b_state h;
         crypto_generichash_blake2b_init(&h, nullptr, 0, sizeof(ret));
@@ -95,13 +95,17 @@ namespace srouter
         crypto_generichash_blake2b_final(&h, reinterpret_cast<uint8_t*>(&ret), sizeof(ret));
 
         // big_to_host so any system will have the same numerical value stored
-        return oxenc::host_to_big(ret);
+        return ret;
     }
 
-    static void update_bucket_hash(uint64_t& bucket_hash, uint64_t old_hash, uint64_t new_hash)
+    static void update_bucket_hash(RCHash& bucket_hash, RCHash old_hash, RCHash new_hash)
     {
-        bucket_hash ^= old_hash;
-        bucket_hash ^= new_hash;
+        static_assert(sizeof(RCHash) == sizeof(uint64_t));
+        uint64_t& bint = *(reinterpret_cast<uint64_t*>(&bucket_hash));
+        uint64_t& oldint = *(reinterpret_cast<uint64_t*>(&old_hash));
+        uint64_t& newint = *(reinterpret_cast<uint64_t*>(&new_hash));
+        bint ^= oldint;
+        bint ^= newint;
     }
 
     static uint8_t bucket_of(const RouterID& rid)
@@ -337,7 +341,14 @@ namespace srouter
         }
 
         oxenc::bt_dict_producer btdp;
-        btdp.append_list("b"sv, rc_bucket_hashes);
+
+        // bt_list_producer::append(std::array) appends as a sublist, so append each element as
+        // a span instead
+        auto btlp = btdp.append_list("b"sv);
+        for (const auto& h : rc_bucket_hashes)
+        {
+            btlp.append(std::span(h));
+        }
 
         selected_path->fetch_relay_contacts(btdp.span<std::byte>(), [this](auto resp) {
             std::string error;

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -1018,8 +1018,6 @@ namespace srouter
         auto [it, new_rc] = known_rcs.try_emplace(rid, std::move(rc));
         auto& stored = it->second;
 
-        update_rc_buckets(rc, /*added=*/true);
-
         bool should_gossip;
         if (new_rc)
         {
@@ -1048,8 +1046,10 @@ namespace srouter
             stored = std::move(rc);
         }
 
+        update_rc_buckets(stored, /*added=*/true);
+
         // We inserted or updated the record, so queue saving it to disk on the disk loop
-        _router.disk_loop.call_soon([rc = stored, path = get_path_by_pubkey(rc.router_id())] { rc.write(path); });
+        _router.disk_loop.call_soon([rc = stored, path = get_path_by_pubkey(stored.router_id())] { rc.write(path); });
 
         return should_gossip;
     }

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -78,8 +78,8 @@ namespace srouter
 
         oxenc::bt_dict_consumer btdc{serialized_rc};
 
-        if (btdc.skip_until("t"sv))
-            throw std::invalid_argument{"Serialized RC did not contain a timestamp."s};
+        if (!btdc.skip_until("t"sv))
+            assert(!"Serialized RC did not contain a timestamp.");
 
         // hash everything up to the literal byte "t" of the key (the key is "1:t")
         auto time_key_and_data = btdc.next_integer<uint64_t>();

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -86,11 +86,19 @@ namespace srouter
         size_t to_hash = time_key_and_data.first.data() - serialized_rc.data();
         crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(serialized_rc.data()), to_hash);
 
-        // hash everything starting from the beginning of the next key to the end
-        // (the size and colon of that key are not hashed)
+        // hash everything starting from the beginning of the next key to the start of the signature
+        // NOTE: because the size and colon of that key are not hashed, multi-byte keys will break
+        // this, so if we ever decide RCs need a multi-byte key we need to make oxenc expose a bit
+        // more data.
         auto after_time = btdc.key();
-        auto after_size = serialized_rc.data() + serialized_rc.size() - after_time.data();
-        crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(after_time.data()), after_size);
+        if (after_time != "~"sv)
+        {
+            if (!btdc.skip_until("~"sv))
+                assert(!"Serialized RC did not contain a timestamp.");
+            auto sig_key_and_data = btdc.next_string();
+            auto after_size = sig_key_and_data.first.data() - after_time.data();
+            crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(after_time.data()), after_size);
+        }
 
         crypto_generichash_blake2b_final(&h, reinterpret_cast<uint8_t*>(&ret), sizeof(ret));
 

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -193,8 +193,6 @@ namespace srouter
         assert(!_bootstraps.empty());
         _bootstrap_running = true;
 
-        if (_rc_fetch_ticker)
-            _rc_fetch_ticker->stop();
         if (_rid_fetch_ticker)
             _rid_fetch_ticker->stop();
 
@@ -333,26 +331,6 @@ namespace srouter
     void NodeDB::fetch_rcs()
     {
         assert(_router.loop.inside());
-        if (_router.is_stopping() || not _router.is_running())
-        {
-            log::debug(logcat, "NodeDB unable to continue RC fetch -- router is stopped!");
-            if (_rc_fetch_ticker)
-                _rc_fetch_ticker->stop();
-            return;
-        }
-
-        std::vector<RouterID> to_fetch{};
-        for (const auto& rid : known_rids)
-        {
-            if (!known_rcs.contains(rid))
-                to_fetch.push_back(rid);
-
-            if (to_fetch.size() == RC_FETCH_COUNT)
-                break;
-        }
-
-        if (to_fetch.empty())
-            return;
 
         path::Path* selected_path = _router.session_endpoint().get_random_active_path();
         if (!selected_path)
@@ -361,20 +339,43 @@ namespace srouter
             return;
         }
 
-        selected_path->fetch_relay_contacts(to_fetch, [this](auto resp) mutable {
+        oxenc::bt_dict_producer btdp;
+        btdp.append_list("b"sv, rc_bucket_hashes);
+
+        selected_path->fetch_relay_contacts(btdp.span<std::byte>(), [this](auto resp) {
             std::string error;
             if (resp.ok())
             {
                 try
                 {
-                    auto rcs = FetchRC::deserialize_response(_router.netid(), oxenc::bt_dict_consumer{resp.body});
-                    log::debug(logcat, "RC fetching was successful; processing {} returned RCs...", rcs.size());
-                    for (auto& rc : rcs)
+                    size_t fetched_count = 0;
+
+                    oxenc::bt_dict_consumer btdc{resp.body};
+                    if (btdc.skip_until("!"sv))
                     {
-                        const auto& rid = rc.router_id();
-                        if (!put_rc(std::move(rc)))
-                            log::debug(logcat, "Not inserting RC for {}, either it is newer or (if relay) ours", rid);
+                        if (auto sv = btdc.consume_string_view(); sv != "OK"sv)
+                            throw std::runtime_error{std::string(sv)};
                     }
+
+                    btdc.required("r");
+                    auto btlc = btdc.consume_list_consumer();
+                    while (!btlc.is_finished())
+                    {
+                        auto rc = RelayContact{btlc.consume_string_view(), _router.netid()};
+                        const auto& rid = rc.router_id();
+                        if (!known_rids.contains(rid))
+                        {
+                            log::info(logcat, "Got RC from relay, but we haven't seen its RouterID, ignoring.");
+                            continue;
+                        }
+                        auto bucket = bucket_of(rid);
+                        log::debug(logcat, "Received RC for relay {} in bucket {:x}", rid, bucket);
+                        if (!put_rc(std::move(rc)))
+                            log::debug(
+                                logcat, "Not inserting RC for {}, seen too recently or functionally unchanged.", rid);
+                        fetched_count++;
+                    }
+                    log::debug(logcat, "RC fetch gave {} RCs"sv, fetched_count);
                 }
                 catch (const std::exception& e)
                 {
@@ -464,6 +465,7 @@ namespace srouter
                 {
                     handle_fetched_router_ids(*results);
                 }
+                fetch_rcs();
             };
             path->send_path_control_message("fetch_rids"sv, {}, std::move(result_cb));
         }
@@ -516,8 +518,6 @@ namespace srouter
 
         if (not _router.is_service_node)
         {
-            _rc_fetch_ticker = _router.loop.call_every(FETCH_INTERVAL, [this] { fetch_rcs(); }, not need_bootstrap);
-
             _rid_fetch_ticker = _router.loop.call_every(FETCH_INTERVAL, [this] { fetch_rids(); }, not need_bootstrap);
         }
 
@@ -554,11 +554,6 @@ namespace srouter
             {
                 _rid_fetch_ticker->start();
                 fetch_rids();
-            }
-            if (_rc_fetch_ticker)
-            {
-                _rc_fetch_ticker->start();
-                fetch_rcs();
             }
             return;
         }
@@ -985,13 +980,6 @@ namespace srouter
             _rid_fetch_ticker.reset();
         }
 
-        if (_rc_fetch_ticker)
-        {
-            log::trace(logcat, "NodeDB clearing RC fetch ticker...");
-            _rc_fetch_ticker->stop();
-            _rc_fetch_ticker.reset();
-        }
-
         if (_purge_ticker)
         {
             log::trace(logcat, "NodeDB clearing purge ticker...");
@@ -1046,7 +1034,8 @@ namespace srouter
             stored = std::move(rc);
         }
 
-        update_rc_buckets(stored, /*added=*/true);
+        if (should_gossip)  // if we actually stored the new RC
+            update_rc_buckets(stored, /*added=*/true);
 
         // We inserted or updated the record, so queue saving it to disk on the disk loop
         _router.disk_loop.call_soon([rc = stored, path = get_path_by_pubkey(stored.router_id())] { rc.write(path); });

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -65,6 +65,68 @@ namespace srouter
         return rand;
     }
 
+    // Hash a serialized RelayContact into 64-bits for identification.
+    // 64-bits is large enough, as we don't need to worry about collisions
+    //
+    // Throws if key "t" is not found (or if somehow the input is not a valid bt-dict)
+    static uint64_t bucket_hash(std::string_view serialized_rc)
+    {
+        uint64_t ret;
+
+        crypto_generichash_blake2b_state h;
+        crypto_generichash_blake2b_init(&h, nullptr, 0, sizeof(ret));
+
+        oxenc::bt_dict_consumer btdc{serialized_rc};
+
+        if (btdc.skip_until("t"sv))
+            throw std::invalid_argument{"Serialized RC did not contain a timestamp."s};
+
+        // hash everything up to the literal byte "t" of the key (the key is "1:t")
+        auto time_key_and_data = btdc.next_integer<uint64_t>();
+        size_t to_hash = time_key_and_data.first.data() - serialized_rc.data();
+        btdc.consume_integer<uint64_t>();
+        crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(serialized_rc.data()), to_hash);
+
+        // hash everything starting from the beginning of the next key to the end
+        // (the size and colon of that key are not hashed)
+        auto after_time = btdc.key();
+        auto after_size = serialized_rc.data() + serialized_rc.size() - after_time.data();
+        crypto_generichash_blake2b_update(&h, reinterpret_cast<const uint8_t*>(after_time.data()), after_size);
+
+        crypto_generichash_blake2b_final(&h, reinterpret_cast<uint8_t*>(&ret), sizeof(ret));
+
+        return ret;
+    }
+
+    static void update_bucket_hash(uint64_t& bucket_hash, uint64_t old_hash, uint64_t new_hash)
+    {
+        bucket_hash ^= old_hash;
+        bucket_hash ^= new_hash;
+    }
+
+    static uint8_t bucket_of(const RouterID& rid)
+    {
+        // choice of which byte is arbitrary, but avoid early bytes for clustered vanity keys
+        // 128 buckets total, so mask off MSB.
+        return rid.as_array()[16] & 0x7f;
+    }
+
+    void NodeDB::update_rc_buckets(const RelayContact& rc, bool added)
+    {
+        const auto& rid = rc.router_id();
+        auto bucket = bucket_of(rid);
+        auto rc_hash = bucket_hash(rc.view());
+        auto& old_hash = rc_hashes[bucket][rid];
+        update_bucket_hash(rc_bucket_hashes[bucket], old_hash, rc_hash);
+        if (!added)
+        {
+            assert(old_hash == rc_hash);
+            rc_hashes[bucket].erase(rid);
+        }
+        else
+            old_hash = rc_hash;
+    }
+
     std::vector<const RelayContact*> NodeDB::get_n_random_rcs(
         int n, bool shuffle, const std::function<bool(const RelayContact&)>& predicate) const
     {
@@ -904,6 +966,12 @@ namespace srouter
                 remove(fpath);
         }
 
+        // initialize rc fetch buckets
+        for (const auto& [rid, rc] : known_rcs)
+        {
+            update_rc_buckets(rc, /*added=*/true);
+        }
+
         log::info(
             logcat, "Loaded {} RCs + 0-RTT tickets for {} relays from disk", known_rcs.size(), _0rtt_tickets.size());
     }
@@ -945,8 +1013,13 @@ namespace srouter
     {
         assert(_router.loop.inside());
 
-        auto [it, new_rc] = known_rcs.try_emplace(rc.router_id(), std::move(rc));
+        const auto& rid = rc.router_id();
+
+        auto [it, new_rc] = known_rcs.try_emplace(rid, std::move(rc));
         auto& stored = it->second;
+
+        update_rc_buckets(rc, /*added=*/true);
+
         bool should_gossip;
         if (new_rc)
         {
@@ -1021,6 +1094,7 @@ namespace srouter
             if (remove(rc))
             {
                 removed.push_back(rid);
+                update_rc_buckets(rc, /*added=*/false);
                 it = known_rcs.erase(it);
             }
             else

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -193,9 +193,6 @@ namespace srouter
         assert(!_bootstraps.empty());
         _bootstrap_running = true;
 
-        if (_rid_fetch_ticker)
-            _rid_fetch_ticker->stop();
-
         struct bs_data
         {
             NodeDB& nodedb;
@@ -402,7 +399,6 @@ namespace srouter
 
         auto results = std::make_shared<std::unordered_map<RouterID, std::unordered_set<RouterID>>>();
         auto result_count = std::make_shared<size_t>(0);
-        size_t try_count{0};
         std::vector<path::Path*> selected_paths;
 
         // In the future, we may want to make paths to selected sources for RID fetching,
@@ -411,20 +407,26 @@ namespace srouter
         // path anyway.
         for (auto& path : _router.session_endpoint().active_paths())
         {
-            if (try_count >= RID_SOURCE_COUNT)
+            if (selected_paths.size() >= RID_SOURCE_COUNT)
                 break;
             auto [itr, inserted] = results->emplace(path.terminal_rid(), std::unordered_set<RouterID>{});
             if (inserted)
             {
-                try_count++;
                 selected_paths.push_back(&path);
             }
         }
-        if (try_count < RID_SOURCE_COUNT)
+
+        if (selected_paths.size() < 2)
+        {
+            log::debug(logcat, "Have fewer than 2 paths, not fetching RouterIDs yet.");
+            _router.loop.call_later(100ms, [this] { fetch_rids(); });
+            return;
+        }
+        else if (selected_paths.size() < RID_SOURCE_COUNT)
             log::info(
                 logcat,
                 "Fetching RIDs from {} sources (want minimum {}, but not enough paths)",
-                try_count,
+                selected_paths.size(),
                 RID_SOURCE_COUNT);
 
         for (auto* path : selected_paths)
@@ -463,9 +465,10 @@ namespace srouter
                 }
                 if (*result_count == results->size())
                 {
+                    // FIXME: call again sooner if enough failed
+                    _router.loop.call_later(FETCH_INTERVAL, [this] { fetch_rids(); });
                     handle_fetched_router_ids(*results);
                 }
-                fetch_rcs();
             };
             path->send_path_control_message("fetch_rids"sv, {}, std::move(result_cb));
         }
@@ -501,6 +504,8 @@ namespace srouter
         known_rids.clear();
         for (const auto& rid : accepted)
             known_rids.insert(rid);
+
+        fetch_rcs();
     }
 
     void NodeDB::start()
@@ -518,7 +523,7 @@ namespace srouter
 
         if (not _router.is_service_node)
         {
-            _rid_fetch_ticker = _router.loop.call_every(FETCH_INTERVAL, [this] { fetch_rids(); }, not need_bootstrap);
+            _router.loop.call_later(100ms, [this] { fetch_rids(); });
         }
 
         _0rtt_saver = _router.disk_loop.make_wakeable([this] { _0rtt_save(); });
@@ -541,22 +546,8 @@ namespace srouter
             log::debug(logcat, "Bootstrap attempt failed ({} consecutive failures)", _bootstrap_fails);
         }
 
-        bool need_bootstrap = num_rcs() < MIN_ACTIVE_RCS;
-        if (not need_bootstrap)
-        {
-            // TODO FIXME: we've now completed a bootstrap and so we want to fire off a full RID
-            // fetch.  This current logic, however, doesn't seem right (but isn't specific to here):
-            // we fire off an rid fetch *and* fire off an RC fetch back to back, on separate timers,
-            // when really they should be dependent.
-            //
-            // But I'm not fixing it here because it needs a more significant overhaul.
-            if (_rid_fetch_ticker)
-            {
-                _rid_fetch_ticker->start();
-                fetch_rids();
-            }
+        if (num_rcs() >= MIN_ACTIVE_RCS)
             return;
-        }
 
         auto cooldown = std::min(BOOTSTRAP_COOLDOWN * (success ? 1 : _bootstrap_fails), BOOTSTRAP_COOLDOWN_MAX);
         log::warning(
@@ -709,7 +700,6 @@ namespace srouter
 
         if (shutdown)
         {
-            _rid_fetch_ticker->stop();
             log::warning(logcat, "Client stopped RouterID fetch without a sucessful response!");
         }
         else
@@ -973,13 +963,6 @@ namespace srouter
 
     void NodeDB::cleanup()
     {
-        if (_rid_fetch_ticker)
-        {
-            log::trace(logcat, "NodeDB clearing rid fetch ticker...");
-            _rid_fetch_ticker->stop();
-            _rid_fetch_ticker.reset();
-        }
-
         if (_purge_ticker)
         {
             log::trace(logcat, "NodeDB clearing purge ticker...");

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -94,7 +94,8 @@ namespace srouter
 
         crypto_generichash_blake2b_final(&h, reinterpret_cast<uint8_t*>(&ret), sizeof(ret));
 
-        return ret;
+        // big_to_host so any system will have the same numerical value stored
+        return oxenc::host_to_big(ret);
     }
 
     static void update_bucket_hash(uint64_t& bucket_hash, uint64_t old_hash, uint64_t new_hash)

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -100,6 +100,9 @@ namespace srouter
                                                              // the rid is +1, missing it is -1.
 
         std::unordered_map<RouterID, RelayContact> known_rcs;
+        std::array<std::unordered_map<RouterID, uint64_t>, 128> rc_hashes;
+        std::array<uint64_t, 128> rc_bucket_hashes{0};
+        void update_rc_buckets(const RelayContact& rc, bool added);
 
         static const std::vector<std::pair<NetID, std::string_view>> bootstrap_fallbacks;
         std::vector<RelayContact> _bootstraps;

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -79,26 +79,7 @@ namespace srouter
         Router& _router;
         const std::filesystem::path _root;
 
-        /******** RouterID/RelayContacts ********/
-
-        /** RouterID mappings
-            Both the following are populated in NodeDB startup with RouterID's stored on disk.
-            - known_rids: meant to persist between Session Router sessions, and is only
-              populated during startup and RouterID fetching. This is meant to represent the
-              client instance's most recent perspective of the network, and record which RouterID's
-              were recently "active" and connected to
-            - unconfirmed_rids: holds new rids returned in fetch requests to be verified by
-           subsequent fetch requests
-            - known_rcs: populated during startup and when RC's are updated both during gossip
-              and periodic RC fetching
-            - bootstrap_seeds: if we are the seed node, we insert the rc's of bootstrap fetch
-           requests senders into this container to "introduce" them to each other
-            - _bootstraps: the standard container for bootstrap RelayContacts
-        */
         std::unordered_set<RouterID> known_rids;
-        std::unordered_map<RouterID, int> unconfirmed_rids;  // Value is the number of votes: seeing
-                                                             // the rid is +1, missing it is -1.
-
         std::unordered_map<RouterID, RelayContact> known_rcs;
         std::array<std::unordered_map<RouterID, uint64_t>, 128> rc_hashes;
         std::array<uint64_t, 128> rc_bucket_hashes{0};

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -22,7 +22,7 @@ namespace srouter
 {
     class Router;
 
-    inline constexpr auto FETCH_INTERVAL{10min};
+    inline constexpr auto FETCH_INTERVAL{5min};
     inline constexpr auto PURGE_INTERVAL{5min};
 
     /*  RC Fetch Constants  */

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -72,6 +72,7 @@ namespace srouter
     inline const std::filesystem::path RC_FILE_EXT{".signed"};
     inline const std::filesystem::path ZRTT_FILE_EXT{".zrtt"};
 
+    using RCHash = std::array<std::byte, 8>;
     class NodeDB
     {
         friend class Router;
@@ -82,8 +83,8 @@ namespace srouter
         std::unordered_set<RouterID> known_rids;
         std::unordered_map<RouterID, RelayContact> known_rcs;
 
-        std::array<std::unordered_map<RouterID, uint64_t>, 128> rc_hashes;
-        std::array<uint64_t, 128> rc_bucket_hashes{0};
+        std::array<std::unordered_map<RouterID, RCHash>, 128> rc_hashes;
+        std::array<RCHash, 128> rc_bucket_hashes{};
 
       public:
         const auto& get_rc_hashes() const { return rc_hashes; }

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -81,8 +81,15 @@ namespace srouter
 
         std::unordered_set<RouterID> known_rids;
         std::unordered_map<RouterID, RelayContact> known_rcs;
+
         std::array<std::unordered_map<RouterID, uint64_t>, 128> rc_hashes;
         std::array<uint64_t, 128> rc_bucket_hashes{0};
+
+      public:
+        const auto& get_rc_hashes() const { return rc_hashes; }
+        const auto& get_rc_buckets() const { return rc_bucket_hashes; }
+
+      private:
         void update_rc_buckets(const RelayContact& rc, bool added);
 
         static const std::vector<std::pair<NetID, std::string_view>> bootstrap_fallbacks;
@@ -117,7 +124,6 @@ namespace srouter
             const RouterID& pk, const std::filesystem::path& extension = RC_FILE_EXT) const;
 
         std::shared_ptr<quic::Ticker> _rid_fetch_ticker;
-        std::shared_ptr<quic::Ticker> _rc_fetch_ticker;
 
         std::shared_ptr<quic::Ticker> _purge_ticker;
 

--- a/src/path/path.cpp
+++ b/src/path/path.cpp
@@ -165,9 +165,9 @@ namespace srouter::path
         send_path_control_message("fetch_rcs", FetchRC::serialize({&needed, 1}), std::move(func));
     }
 
-    void Path::fetch_relay_contacts(std::span<const RouterID> needed, std::function<void(path_control_response)> func)
+    void Path::fetch_relay_contacts(std::span<const std::byte> body, std::function<void(path_control_response)> func)
     {
-        send_path_control_message("fetch_rcs", FetchRC::serialize(needed), std::move(func));
+        send_path_control_message("fetch_rcs", body, std::move(func));
     }
 
     void Path::find_client_contact(const PubKey& blinded_pk, std::function<void(path_control_response)> func)

--- a/src/path/path.hpp
+++ b/src/path/path.hpp
@@ -93,7 +93,7 @@ namespace srouter::path
 
         void fetch_relay_contact(const RouterID& needed, std::function<void(path_control_response)> func);
 
-        void fetch_relay_contacts(std::span<const RouterID> needed, std::function<void(path_control_response)> func);
+        void fetch_relay_contacts(std::span<const std::byte> body, std::function<void(path_control_response)> func);
 
         void find_client_contact(const PubKey& blinded_pk, std::function<void(path_control_response)> func);
 


### PR DESCRIPTION
    Ideally we don't want clients fetching every RC frequently, even though
    it is currently only a couple hundred kilobytes.  With enough clients
    and enough frequency, that's still an annoying amount of data transfer,
    and wasted processing.  To that end, this commit adds a bucketed hashing
    system for RCs:
    
    - Relays are divided into 128 buckets based on the 17th (arbitrary) byte
      of their RouterID.  A later byte is chosen to avoid clustering for
      nodes with "vanity" public keys, though perhaps clustering those would
      be a good thing for this?
    - Serialized RCs are hashed (*except* for the timestamp), and these
      hashes are cached.
    - Each bucket has a "hash" which is simply the XOR of all the RC hashes
      which belong to that bucket.  XOR is fine here because there is no
      cryptographic concern and it makes insertion/removal trivial.
    
    This is all so that a client can request all RCs and provide *its*
    current hash for each bucket, and the relay can respond with all the RCs
    for *that* bucket, without the client needing to refresh the full RC
    set.
    
    The timestamp is ignored so that RC updates which are basically saying
    "yes I'm still here, but nothing has changed" don't need to be pushed to
    clients.  If an RC expires, the client will purge it as expired, then
    its hash for that bucket will mismatch and it will get the newest RC for
    that node.
