### PR TITLE
Avoid warning from attempting to build a path too early

### DIFF
--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1283,15 +1283,13 @@ namespace srouter::session
             _intro_update_processed = true;
         }
 
-        int n_paths = num_paths();
-
         if (_current_path && _current_path->is_dead)
         {
             _current_path.reset();
             _dead_path = true;
         }
 
-        if (!_current_path && n_paths)
+        if (!_current_path && num_active_paths())
             // We don't have a current path, possibly because we just dropped it in the above loop,
             // so select a new one to make our current path
             select_new_current();


### PR DESCRIPTION
If we have paths in progress but none built yet, we were entering select_new_current(), but then it was failing and warning because there are no active paths it can use:

    [session:warning|session/session.cpp:1090] Unable to select new path to [PUBKEY].sesh: no acceptable active paths

This avoids entering select_new_current() until we have active paths and it can usefully do something.