### PR TITLE
Fix deadlock or crash during shutdown

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -291,7 +291,7 @@ local clang(version) = debian_pipeline(
 local full_llvm(version) = debian_pipeline(
   'Debian sid/llvm-' + version,
   docker_base + 'debian-sid-clang',
-  deps=default_deps(add=['clang-' + version, ' lld-' + version, ' libc++-' + version + '-dev', 'libc++abi-' + version + '-dev', 'libngtcp2-crypto-gnutls-dev', 'libngtcp2-dev'],
+  deps=default_deps(add=['clang-' + version, ' lld-' + version, ' libc++-' + version + '-dev', 'libc++abi-' + version + '-dev', 'libunwind-' + version + '-dev', 'libngtcp2-crypto-gnutls-dev', 'libngtcp2-dev'],
                     remove='g++'),
   oxen_repo=[],
   cmake_extra='-DCMAKE_C_COMPILER=clang-' + version +

--- a/src/link/endpoint.cpp
+++ b/src/link/endpoint.cpp
@@ -797,6 +797,8 @@ namespace srouter::link
         });
     }
 
+    Endpoint::~Endpoint() { *canary = false; }
+
     void Endpoint::on_conn_closed(quic::Connection& conn, uint64_t ec)
     {
         auto alpn = conn.selected_alpn();
@@ -815,13 +817,26 @@ namespace srouter::link
             return;
         }
 
-        router.loop.call([this, connptr = conn.shared_from_this(), ec] {
-            auto& conn = *connptr;
-            auto alpn = conn.selected_alpn();
+        std::optional<RouterID> rid;
+        if (conn.remote_key().size() == RouterID::SIZE)
+            rid.emplace(conn.remote_key().first<RouterID::SIZE>());
 
-            std::optional<RouterID> rid;
-            if (conn.remote_key().size() == RouterID::SIZE)
-                rid.emplace(conn.remote_key().first<RouterID::SIZE>());
+        // NB: we must not capture a shared_ptr to conn here, because this lambda could outlive
+        // `this`; the canary lets us early-return if that happens, but the Connection destruction
+        // relies on `this.loop` to destroy: thus if we capture it we could delay that destruction
+        // attempt beyond the end of `this.loop`.  Thus we capture everything we need into the
+        // lambda here, while we are still in the network loop.
+
+        router.loop.call([this,
+                          alive = canary,
+                          conn_refid = conn.reference_id(),
+                          alpn,
+                          rid = std::move(rid),
+                          remote_addr = conn.remote(),
+                          ec,
+                          was_inbound = conn.is_inbound()] {
+            if (!*alive)
+                return;
 
             bool found = false;
 
@@ -833,14 +848,14 @@ namespace srouter::link
                 {
                     assert(router.is_service_node);
                     auto& relcon = it->second;
-                    if (relcon.inbound && connptr == relcon.inbound->conn)
+                    if (relcon.inbound && relcon.inbound->conn && relcon.inbound->conn->reference_id() == conn_refid)
                     {
                         relcon.close(true);
                         found = true;
                         log::debug(
                             logcat, "Inbound connection from {} closed (ec={})", rid->to_network_address(true), ec);
                     }
-                    if (relcon.outbound && connptr == relcon.outbound->conn)
+                    if (relcon.outbound && relcon.outbound->conn && relcon.outbound->conn->reference_id() == conn_refid)
                     {
                         relcon.close(false);
                         found = true;
@@ -875,10 +890,10 @@ namespace srouter::link
                     log::debug(
                         logcat,
                         "Closed redundant connection {} {} @ {} (cid={})",
-                        conn.is_inbound() ? "from" : "to",
+                        was_inbound ? "from" : "to",
                         rid->to_network_address(true),
-                        conn.remote(),
-                        conn.reference_id());
+                        remote_addr,
+                        conn_refid);
                     found = true;
                 }
             }
@@ -886,11 +901,11 @@ namespace srouter::link
             {
                 if (router.is_service_node)
                 {
-                    assert(conn.is_inbound());  // Relays do make outbound client conns for testing,
-                                                // but they do not use this close callback.
-                    if (auto it = inbound_clients.find(conn.reference_id()); it != inbound_clients.end())
+                    assert(was_inbound);  // Relays do make outbound client conns for testing,
+                                          // but they do not use this close callback.
+                    if (auto it = inbound_clients.find(conn_refid); it != inbound_clients.end())
                     {
-                        log::debug(logcat, "Client connection from {} closed (ec={})", conn.remote(), ec);
+                        log::debug(logcat, "Client connection from {} closed (ec={})", remote_addr, ec);
                         it->second->close();
                         inbound_clients.erase(it);
                         found = true;
@@ -898,9 +913,10 @@ namespace srouter::link
                 }
                 else
                 {
-                    assert(conn.is_outbound());
+                    assert(!was_inbound);
 
-                    if (auto it = client_conns.find(*rid); it != client_conns.end() and connptr == it->second->conn)
+                    if (auto it = client_conns.find(*rid); it != client_conns.end() && it->second && it->second->conn
+                        && it->second->conn->reference_id() == conn_refid)
                     {
                         log::debug(
                             logcat,
@@ -912,12 +928,13 @@ namespace srouter::link
                     }
                 }
             }
-            else if (conn.is_outbound())
+            else if (!was_inbound)
             {
                 // Unknown or empty ALPN -- this is an outbound conn that didn't establish (and thus
                 // didn't negotiate the ALPN):
                 assert(rid);  // Outbound conns start out with the target pubkey known
-                if (auto it = pending_outbound.find(*rid); it != pending_outbound.end() and connptr == it->second->conn)
+                if (auto it = pending_outbound.find(*rid); it != pending_outbound.end() && it->second
+                    && it->second->conn && it->second->conn->reference_id() == conn_refid)
                 {
                     pending_outbound.erase(it);
                     found = true;
@@ -931,10 +948,10 @@ namespace srouter::link
                 log::warning(
                     logcat,
                     "Closed connection {} {} @ {} (cid={}, ec={})",
-                    conn.is_inbound() ? "from" : "to",
+                    was_inbound ? "from" : "to",
                     rid ? rid->to_string() : "",
-                    conn.remote(),
-                    conn.reference_id(),
+                    remote_addr,
+                    conn_refid,
                     ec);
 
             if (not router.is_service_node)

--- a/src/link/endpoint.hpp
+++ b/src/link/endpoint.hpp
@@ -83,10 +83,16 @@ namespace srouter::link
       public:
         explicit Endpoint(Manager& lm);
 
+        ~Endpoint();
+
         Manager& manager;
         Router& router;
 
       private:
+        // The network loop object.  This *must* be declared before most of the below as some of the
+        // things below have destructors that run in this loop.
+        std::unique_ptr<quic::Loop> loop;
+
         // Stores established relay-to-relay connections; only used by service nodes.
         std::unordered_map<RouterID, relay_conn> relay_conns;
 
@@ -114,11 +120,14 @@ namespace srouter::link
         // only.
         std::unordered_map<quic::ConnectionID, std::shared_ptr<link::Connection>> inbound_clients;
 
-        std::unique_ptr<quic::Loop> loop;
         std::shared_ptr<quic::Endpoint> endpoint;
         std::shared_ptr<quic::Ticker> redundancy_ticker;
         std::shared_ptr<quic::Ticker> dereg_conn_ticker;
         std::shared_ptr<quic::GNUTLSCreds> tls_creds;
+
+        // Canary object that gets set to false during destruction to help short-circuit lambda that
+        // could potentially outlive `this`:
+        std::shared_ptr<bool> canary = std::make_shared<bool>(true);
 
       public:
         void start_tickers();


### PR DESCRIPTION
This solves issues during destruction where we could get a segfault or a deadlock because of race conditions between connection close and link endpoint destruction.

Basically what happened was:
- during Router stop, link_endpoint gets destroyed.
- that destruction closes all the connections, firing the on_conn_closed callbacks during destruction.
- those callbacks were capturing a shared_ptr to the closed connection in a lambda job pushed onto the router loop
- that router loop job can't run yet because we're already inside a router job doing the shutdown that triggered all of this
- we get "router is stopped"
- the queued cleanup code fires.

There were multiple things wrong here:
- trying to call `selected_alpn` (or `remote()`) would crash or deadlock because the network loop was gone, but those accessors go through a call_get.
- the cleanup job had an invalid `this` pointer because link_endpoint was gone.
- the cleanup job was also capturing a shared_ptr<Connection> to a Connection tied to the link_endpoint's loop, and so attempting to destroy that lambda (even if we early return) could crash or deadlock because the loop that handles the Connection destructor isn't around anymore.

This reworks it to fix it:
- adds a shared_ptr canary we capture to make sure we are still alive, to early-return from the lambda if `this` isn't valid anymore.
- captures all the conn details we need in the lambda, rather than capturing a shared_ptr to get it out of inside the lambda.
- changes all the "is the conn pointer the same" logic to use the reference id rather than pointer (since we can't keep the conn pointer anymore).