### PR TITLE
libsession SNS resolution; add different "connected" states

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -89,6 +89,7 @@ local debian_pipeline(name,
                   'echo "man-db man-db/auto-update boolean false" | debconf-set-selections',
                   apt_get_quiet + ' update',
                   apt_get_quiet + ' install -y eatmydata',
+                  'eatmydata ' + apt_get_quiet + ' dist-upgrade -y',
                 ] + (
                   if std.length(oxen_repo) > 0 then [
                     'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y lsb-release',
@@ -99,7 +100,6 @@ local debian_pipeline(name,
                   ] else []
                 ) + extra_setup
                 + [
-                  'eatmydata ' + apt_get_quiet + ' dist-upgrade -y',
                   'eatmydata ' + apt_get_quiet + ' install --no-install-recommends -y gdb cmake git pkg-config ccache ' + std.join(' ', deps),
                   'mkdir build',
                   'cd build',

--- a/contrib/libsession-router_jank_test.cpp
+++ b/contrib/libsession-router_jank_test.cpp
@@ -1,5 +1,6 @@
 #include <session/router.hpp>
 
+#include <chrono>
 #include <csignal>
 #include <exception>
 #include <filesystem>
@@ -17,7 +18,7 @@ int main(int argc, char** argv)
 {
     if (argc <= 1)
     {
-        std::cerr << "USAGE: " << argv[0] << " {WHATEVER.loki | WHATEVER.snode}\n";
+        std::cerr << "USAGE: " << argv[0] << " {PUBKEY.sesh | PUBKEY.snode | ONS.loki}\n";
         return 1;
     }
 
@@ -48,13 +49,47 @@ int main(int argc, char** argv)
     {
         conn_prom.get_future().get();
 
-        //std::this_thread::sleep_for(500ms);
-        std::cout << "\x1b[33;1mINITIATING SESSION TO " << target << "\x1b[0m\n\n" << std::flush;
+        auto start = std::chrono::steady_clock::now();
+        std::cout << "\x1b[33;1mINITIATING SESSION TO \x1b[34;1m" << target << "\x1b[0m\n\n" << std::flush;
+
+        std::promise<std::string> resolve_prom;
+        srouter->resolve(target, [&](std::optional<std::string> a, bool timeout) {
+            if (a)
+            {
+                if (*a != target)
+                {
+                    auto now = std::chrono::steady_clock::now();
+                    std::cout << "\n\n\x1b[35;1mRESOLVED SNS \x1b[34;1m" << target << "\x1b[35;1m TO \x1b[34;1m" << *a
+                              << "\x1b[35;1m in " << std::chrono::round<std::chrono::milliseconds>(now - start).count()
+                              << "ms\x1b[0m\n\n";
+                    start = now;
+                }
+                resolve_prom.set_value(std::move(*a));
+                return;
+            }
+
+            try
+            {
+                throw std::runtime_error{
+                    "Failed to resolve ("s + (timeout ? "timeout" : "does not exist") + ") target \x1b[34;1m" + target};
+            }
+            catch (...)
+            {
+                resolve_prom.set_exception(std::current_exception());
+            }
+        });
+
+        target = resolve_prom.get_future().get();
+
         srouter->establish_udp(
             target,
             12345,
-            [&prom](auto udp_info) {
-                std::cout << "\n\x1b[32;1mUDP bound to port [::1]:" << udp_info.local_port << "\x1b[0m\n\n" << std::flush;
+            [&prom, &start](auto udp_info) {
+                std::cout
+                    << "\n\x1b[32;1mSession established ("
+                    << std::chrono::round<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count()
+                    << "ms); UDP bound to port [::1]:" << udp_info.local_port << "\x1b[0m\n\n"
+                    << std::flush;
                 prom.set_value();
             },
             [&prom]() {

--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -87,25 +87,41 @@ namespace session::router
         ~SessionRouter();
 
         // Schedules the given callback to be fired when Session Router edge connections are mostly
-        // established (and thus Session Router is ready to start building paths).  If Session Router is already
-        // established, this will schedule an immediate invocation of the callback.
+        // established (and thus Session Router is ready to start building paths).  If Session
+        // Router is already established, this will schedule an immediate invocation of the
+        // callback.
+        //
+        // If the `with_path` argument is true (or omitted) then the callback instead fires with
+        // there are edge connections *and* at least one inbound/utility path, which is needed to be
+        // able to query the network for things like ONS records and client contacts.  `false`, on
+        // the other hand, will fire sooner without requiring a path be completed: it is suitable
+        // for signalling when Session Router is sufficient connected to start building sessions to
+        // relays.
         //
         // If persist is true then the callback will be stored and called *each* time Session Router enters
         // the connected state (i.e. it will be called again if Session Router loses all connectivity and
-        // then regains connections).
-        void on_connected(std::function<void()> callback, bool persist = false);
+        // then regains connections and/or paths).
+        void on_connected(std::function<void()> callback, bool with_path = true, bool persist = false);
 
-        // Schedules the given callback to be fired when Session Router becomes fully disconnected, i.e.
-        // loses all established edge connections.  If persist is true then the callback will be
-        // fired *each* time Session Router transitions from connected to disconnected state.  If Session Router
+        // Schedules the given callback to be fired when Session Router becomes fully disconnected,
+        // i.e.  loses all established edge connections or its last inbound path.  When `with_path`
+        // is given and false, this tracks edge disconnection, which means the instance has lost all
+        // connectivity; when omitted or true, the callback is also fired if the last inbound path
+        // is lost, signalling that network querying and client sessions cannot currently work, but
+        // sessions to relays may still be functional.
+        //
+        // If `persist` is true then the callback will be fired *each* time Session Router
+        // transitions from connected to disconnected state.  If Session Router
         // is not currently connected then the callback will be scheduled immediately.
-        void on_disconnected(std::function<void()> callback, bool persist = false);
+        void on_disconnected(std::function<void()> callback, bool with_path = true, bool persist = false);
 
-        // Establishes a session to the given remote (.loki or .snode), with an IPv6 localhost port
-        // mapped to a port on the remote.  A limited number of packets (e.g. to establish a
-        // connection) can be sent to the mapped port immediately even before the session
-        // establishes: a few packets will be queued and delivered once (and if) the session
+        // Establishes a session to the given remote (pubkey.sesh or pubkey.snode), with an IPv6
+        // localhost port mapped to a port on the remote.  A limited number of packets (e.g. to
+        // establish a connection) can be sent to the mapped port immediately even before the
+        // session establishes: a few packets will be queued and delivered once (and if) the session
         // establishes.
+        //
+        // (This method does not accept SNS names: you need to call resolve_sns() first for that).
         //
         // The returned object contains the port information.  The tunnel will remain active until
         // drop_udp() is called with the same remote address and port (or the SessionRouter instance
@@ -121,13 +137,14 @@ namespace session::router
         // call.  Note that `on_established` can be called immediately (i.e. before
         // `establish_udp()` returns), if a session to the remote is already established.
         //
-        // `on_timeout` is invoked instead of `on_established` if the session fails to establish for
-        // whatever reason, with a string giving a descriptive reason.  Note that `on_timeout` is
-        // *not* called if the call throws (such as if given an unparseable address).  Note that an
-        // `on_timeout` call does *not* mean the tunnel has been cancelled: it will remain and future
-        // attempts to connect to the tunnel port will attempt to (re-)establish the session.  If
-        // you want to cancel it on session initiation failure, call `close_udp()` from within the
-        // on_timeout callback.
+        // `on_timeout` is invoked instead of `on_established` if the session fails to establish.
+        // Note that:
+        // - `on_timeout` is *not* called if the call throws (such as if given an unparseable
+        //   address).
+        // - an `on_timeout` call does *not* mean the tunnel has been cancelled: it will remain
+        //   active and future attempts to connect to the tunnel port will attempt to (re-)establish
+        //   the session.  If you want to cancel it on session initiation failure, you must call
+        //   `close_udp()` from within the on_timeout callback.
         //
         // Take care not to use very slow or blocking code inside the callbacks: they are called
         // from Session Router's logic thread (and so any blocking will stall Session Router).
@@ -140,6 +157,29 @@ namespace session::router
         // Closes a tunnel socket to the given remote/port combination, releasing any internal
         // mappings set up from previous connections through the tunnel.
         void close_udp(std::string_view remote, uint16_t port);
+
+        // Takes an ONS/SNS address such as "blocks.loki" and attempts to resolve it to a Session
+        // Router client (aka hidden service) address such as
+        // "kcpyawm9se7trdbzncimdi5t7st4p5mh9i1mg7gkpuubi4k4ku1y.sesh".
+        //
+        // This method will also accept a full network address (PUBKEY.sesh or PUBKEY.snode), in
+        // which case it simply instantly calls the callback with the same address.  (This
+        // capability is designed to allow this method to be used with an address that could be
+        // either ONS/SNS or direct pubkey).
+        //
+        // When the name is resolved, the callback will be invoked with the network address.  If the
+        // name does not exist or a timeout occurs it will be invoked with nullopt and a second
+        // argument that is true if we timed out (i.e. don't know), false if we got a definitive
+        // answer from the network that the name does not exist.  (The bool should not be used when
+        // `addr` has a value).
+        //
+        // It is possible for the callback to be called instantly (i.e. before resolve_sns returns)
+        // if the result is already cached, or when given a direct pubkey address rather than a
+        // resolvable ONS/SNS name.
+        //
+        // This method will throw an invalid_argument exception if the given address is neither a
+        // valid pubkey address nor potentially valid ONS/SNS address.
+        void resolve(std::string address, std::function<void(std::optional<std::string> addr, bool timeout)> callback);
 
         // If we have a session with the given remote, returns the path we are currently using for
         // that session.  In the case of a client<->client session, this will be the relay which we

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -490,6 +490,8 @@ namespace srouter::handlers
     {
         log::debug(logcat, "Successfully built path {}", p);
 
+        router.on_inbound_path_change(true);
+
         if (not router.config().network.is_reachable)
             return;
 
@@ -509,6 +511,8 @@ namespace srouter::handlers
         log::info(logcat, "Inbound active paths changed; re-publishing client contact");
         update_and_publish_localcc();
     }
+
+    void SessionEndpoint::no_established_paths_left() { router.on_inbound_path_change(false); }
 
     void SessionEndpoint::on_path_build_failure(int64_t /*build_id*/, path::Path* path, bool timeout)
     {

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -63,6 +63,7 @@ namespace srouter
 
             void on_path_build_failure(int64_t build_id, path::Path* path, bool timeout) override;
             void on_path_build_success(int64_t build_id, path::Path& p) override;
+            void no_established_paths_left() override;
 
             void session_post_init(std::shared_ptr<session::InboundSession> new_session);
 

--- a/src/path/path_handler.cpp
+++ b/src/path/path_handler.cpp
@@ -70,6 +70,7 @@ namespace srouter::path
     {
         Lock_t lock{paths_mutex};
 
+        int still_established = 0;
         int n = 0;
         for (auto itr = _paths.begin(); itr != _paths.end();)
         {
@@ -80,11 +81,19 @@ namespace srouter::path
                 n++;
             }
             else
+            {
+                if (itr->second and itr->second->is_established())
+                    still_established++;
                 ++itr;
+            }
         }
 
         if (n)
+        {
             log::debug(logcat, "{} expired paths dropped", n);
+            if (!still_established)
+                no_established_paths_left();
+        }
     }
 
     void PathHandler::invalidate_paths()
@@ -121,7 +130,7 @@ namespace srouter::path
 
         expire_paths(now);
 
-        if (not router.is_service_node and not router.is_connected())
+        if (not router.is_service_node and not router.is_edge_connected())
             // If we are not yet fully connected then we can't initiate path builds.  (In theory we
             // could whe not yet fully connected, but don't want to because that would bias edge
             // router selection towards faster ones).

--- a/src/path/path_handler.hpp
+++ b/src/path/path_handler.hpp
@@ -99,6 +99,15 @@ namespace srouter
 
             void expire_paths(sys_ms now);
 
+            // Called whenever our last a path gets dropped (expires naturally or was forced to expire
+            // early because of timeout) if we have no established paths.  This is mainly used by
+            // SessionEndpoint to be able to trigger Router's "on_disconnected" callbacks.  Note
+            // that this is not stateful, i.e. it can potentially fire multiple times without having
+            // actually established new paths in between calls.
+            //
+            // The default does nothing.
+            virtual void no_established_paths_left() {}
+
             // In case we know none of our paths are still valid, e.g. we received a close on a
             // relay session so we assume it's restarting.
             void invalidate_paths();

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -15,6 +15,7 @@
 #include "util/random.hpp"
 #include "util/service_manager.hpp"
 #include "util/time.hpp"
+#include "util/try_calling.hpp"
 
 #include <nlohmann/json.hpp>
 #include <oxen/log.hpp>
@@ -878,65 +879,49 @@ namespace srouter
         tick();
     }
 
-    bool Router::is_connected() const
+    bool Router::is_edge_connected() const
     {
-        return loop.call_get([this] { return _is_connected; });
+        return loop.call_get([this] { return _is_edge_connected; });
+    }
+    bool Router::is_path_connected() const
+    {
+        return loop.call_get([this] { return _is_edge_connected && _has_established_paths; });
     }
 
-    void Router::on_connected(std::function<void()> callback, bool persistent)
-    {
-        if (!callback)
-            return;
-        loop.call([this, callback = std::move(callback), persistent] {
-            if (_is_connected)
-                try
-                {
-                    callback();
-                }
-                catch (const std::exception& e)
-                {
-                    log::error(logcat, "Uncaught exception calling on_connected callback: {}", e.what());
-                }
-
-            if (persistent or not _is_connected)
-                _on_connected.emplace_back(std::move(callback), persistent);
-        });
-    }
-
-    void Router::on_disconnected(std::function<void()> callback, bool persistent)
+    void Router::on_connected(std::function<void()> callback, bool with_paths, bool persistent)
     {
         if (!callback)
             return;
-        loop.call([this, callback = std::move(callback), persistent] {
-            if (not _is_connected)
-                try
-                {
-                    callback();
-                }
-                catch (const std::exception& e)
-                {
-                    log::error(logcat, "Uncaught exception calling on_disconnected callback: {}", e.what());
-                }
+        loop.call([this, with_paths, callback = std::move(callback), persistent] {
+            bool fire_now = _is_edge_connected && (_has_established_paths || !with_paths);
+            if (fire_now)
+                try_calling(logcat, callback);
 
-            if (persistent or _is_connected)
-                _on_disconnected.emplace_back(std::move(callback), persistent);
+            if (persistent || !fire_now)
+                (with_paths ? _on_path_connected : _on_edge_connected).emplace_back(std::move(callback), persistent);
         });
     }
 
-    static void process_on_conn_callbacks(
-        std::list<std::pair<std::function<void()>, bool>> callbacks, std::string_view type)
+    void Router::on_disconnected(std::function<void()> callback, bool with_paths, bool persistent)
+    {
+        if (!callback)
+            return;
+        loop.call([this, callback = std::move(callback), persistent, with_paths] {
+            bool fire_now = !_is_edge_connected || (with_paths && !_has_established_paths);
+            if (fire_now)
+                try_calling(logcat, callback);
+
+            if (persistent || !fire_now)
+                (with_paths ? _on_path_disconnected : _on_path_connected).emplace_back(std::move(callback), persistent);
+        });
+    }
+
+    static void process_on_conn_callbacks(std::list<std::pair<std::function<void()>, bool>> callbacks)
     {
         for (auto it = callbacks.begin(); it != callbacks.end();)
         {
             auto& [f, persist] = *it;
-            try
-            {
-                f();
-            }
-            catch (const std::exception& e)
-            {
-                log::error(logcat, "Uncaught exception calling {} callback: {}", type, e.what());
-            }
+            try_calling(logcat, f);
             if (persist)
                 ++it;
             else
@@ -949,20 +934,21 @@ namespace srouter
         assert(loop.inside());
 
         int conns = link_endpoint().num_relay_conns();
-        if (conns == 0 and _is_connected)
+        if (conns == 0 and _is_edge_connected)
         {
-            _is_connected = false;
+            _is_edge_connected = false;
 
             log::warning(log_global, "Session Router is no longer connected to the network!");
 
-            process_on_conn_callbacks(_on_disconnected, "on_disconnected");
+            process_on_conn_callbacks(_on_path_disconnected);
+            process_on_conn_callbacks(_on_edge_disconnected);
         }
         else if (
-            not _is_connected
+            not _is_edge_connected
             and conns * CLIENT_CONNECTED_THRESHOLD::den
                 >= config().paths.edge_connections * CLIENT_CONNECTED_THRESHOLD::num)
         {
-            _is_connected = true;
+            _is_edge_connected = true;
 
             log::info(
                 log_global,
@@ -971,7 +957,41 @@ namespace srouter
                 conns,
                 config().paths.edge_connections);
 
-            process_on_conn_callbacks(_on_connected, "on_connected");
+            process_on_conn_callbacks(_on_edge_connected);
+            if (_has_established_paths)
+                process_on_conn_callbacks(_on_path_connected);
+        }
+    }
+
+    void Router::on_inbound_path_change(bool connected)
+    {
+        if (connected == _has_established_paths)
+            return;
+
+        _has_established_paths = connected;
+
+        if (_has_established_paths)
+        {
+            if (!_is_edge_connected)
+            {
+                // If we aren't edge connected then an established path isn't enough to push us into
+                // "path connected" state, so do nothing for now aside from setting the cool.  When
+                // we hit edge connected state (above) it will fire the _on_path_connected callbacks.
+                return;
+            }
+
+            process_on_conn_callbacks(_on_path_connected);
+        }
+        else
+        {
+            if (!_is_edge_connected)
+            {
+                // If we already lost all our edges then the path disconnected callbacks were
+                // already fired as part of that, so we don't need to call them now.
+                return;
+            }
+
+            process_on_conn_callbacks(_on_path_disconnected);
         }
     }
 

--- a/src/router/router.hpp
+++ b/src/router/router.hpp
@@ -119,7 +119,13 @@ namespace srouter
         std::atomic<bool> _is_stopping{false};
         std::atomic<bool> _is_running{false};
 
-        bool _is_connected{false};
+        // True once we have enough edges
+        bool _is_edge_connected{false};
+        // True once we have at least one inbound/utility path.  Note that this is subtly different
+        // than the `is_path_connected()` method and the on_connected triggers: this only tracks
+        // whether we have paths, but the public path connectivity checks also require edge
+        // connections.
+        bool _has_established_paths{false};
 
         // Not actually shared, but not available at all in non-full builds.
         std::shared_ptr<consensus::reachability_testing> _router_testing;
@@ -166,13 +172,14 @@ namespace srouter
         steady_ms _next_dereg_warning{steady_now_ms() + 15s};
 
         // Application callback(s) to fire as soon as we reach "connected" or "disconnected" status,
-        // which means when we have established our target number of edge connections or lost all
-        // edge connections, respectively.  Typically used as a "ready-to-go" callback during
-        // initialization.  The bool value indicates whether the callback is persistent (true) or
-        // one-time (false).  Note that callbacks are only called when the connected state changes:
-        // that is when we were disconnected and became connected, or were connected and became
-        // disconnected.
-        std::list<std::pair<std::function<void()>, bool>> _on_connected, _on_disconnected;
+        // with different versions for "edge connected" or "path connected".
+        //
+        // Typically used as a "ready-to-go" callback during initialization.  The bool is whether
+        // the callback is persistent (true) or one-time (false).  Note that callbacks are only
+        // called when the connected state changes: that is when we were disconnected and became
+        // connected, or were connected and became disconnected.
+        std::list<std::pair<std::function<void()>, bool>> _on_edge_connected, _on_edge_disconnected, _on_path_connected,
+            _on_path_disconnected;
 
         // These aren't actually shared, but we unique_ptr requires destructor visibility, which
         // embedded-only clients won't have as they don't compile any RPC code.
@@ -311,24 +318,40 @@ namespace srouter
 
         std::string status_line();
 
-        // Returns the client connectivity status: we enter "connected" state once the target number
-        // of edge router connections is reached, and we lose connected state when we lose all edge
-        // connections.  Application code can monitor this state by setting callbacks via
-        // `on_connected`/`on_disconnected`.
-        bool is_connected() const;
+        // Returns the client "edge connectivity" status: we enter "edge connected" state once the
+        // target number of edge router connections is reached, and we lose connected state when we
+        // lose all edge connections.  Application code can monitor this state by setting callbacks
+        // via `on_connected`/`on_disconnected`.
+        bool is_edge_connected() const;
 
-        // Adds an application callback to invoke when the connectivity state changes to
-        // "connected".  If the state is already connected when this is called, the callback will be
-        // invoked immediately.  If `persistent` is true then the callback will be stored and called
-        // again if the state leaves and re-enters the connected state.
-        void on_connected(std::function<void()> callback, bool persistent);
+        // Returns the client "path connectivity" status: this requires edge connectivity (see
+        // above) but also requires that the router has at least one established inbound/utility
+        // path, as is required for things like SNS queries and client contact retrieval and
+        // publishing.
+        bool is_path_connected() const;
+
+        //
+        // If `with_paths` is false, this returns true if we have enough edge connections, which is
+        // enough to be able to build outbound sessions to routers.  If true, the returns true if we
+        // have edge connections *and* at least one inbound/utility path, which is needed for things
+        // like client contact lookups and ONS queries.
+
+        // Adds an application callback to invoke when the connectivity state changes to "connected"
+        // (see is_connected).  If the state is already connected when this is called, the callback
+        // will be invoked immediately.  If `persistent` is true then the callback will be stored
+        // and called again if the state leaves and re-enters the connected state.
+        void on_connected(std::function<void()> callback, bool with_paths, bool persistent);
 
         // Like `is_connected`, but fires on disconnections.
-        void on_disconnected(std::function<void()> callback, bool persistent);
+        void on_disconnected(std::function<void()> callback, bool with_paths, bool persistent);
 
         // Internal method: called from link::Endpoint to re-check and possibly change connected
         // state when a client edge connection is established or lost.
         void on_edge_conn_change();
+
+        // Internal method: called from SessionEndpoint when we establish (true) an inbound/utility
+        // path and previously had none; or when we lose our last inbound/utility path (false).
+        void on_inbound_path_change(bool connected);
 
         // Called when we get a relay testing ping to pass through to the router tester so that it
         // can warn if we haven't received pings in a long time.

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -63,14 +63,14 @@ namespace session::router
         context->wait();
     }
 
-    void SessionRouter::on_connected(std::function<void()> callback, bool persist)
+    void SessionRouter::on_connected(std::function<void()> callback, bool with_path, bool persist)
     {
-        context->router->on_connected(std::move(callback), persist);
+        context->router->on_connected(std::move(callback), with_path, persist);
     }
 
-    void SessionRouter::on_disconnected(std::function<void()> callback, bool persist)
+    void SessionRouter::on_disconnected(std::function<void()> callback, bool with_path, bool persist)
     {
-        context->router->on_disconnected(std::move(callback), persist);
+        context->router->on_disconnected(std::move(callback), with_path, persist);
     }
 
     tunnel_info SessionRouter::establish_udp(
@@ -79,7 +79,9 @@ namespace session::router
         std::function<void(tunnel_info)> on_established,
         std::function<void()> on_timeout)
     {
-        // FIXME: check for valid ONS, and if so, we need to defer the lookup as well
+        if (srouter::is_valid_sns(remote))
+            throw std::invalid_argument{"establish_udp requires a network pubkey address, not an ONS/SNS addresses"};
+
         srouter::NetworkAddress netaddr;
         try
         {
@@ -143,7 +145,6 @@ namespace session::router
 
     void SessionRouter::close_udp(std::string_view remote, uint16_t port)
     {
-        // FIXME: check for valid ONS, and if so, we need to defer the lookup as well
         srouter::NetworkAddress netaddr;
         try
         {
@@ -163,6 +164,39 @@ namespace session::router
         for (const auto& [rid, ip] : info.relays)
             path.emplace_back(srouter::NetworkAddress{rid, false}.to_string(), ip.to_string());
         return path;
+    }
+
+    void SessionRouter::resolve(
+        std::string address, std::function<void(std::optional<std::string> addr, bool timeout)> callback)
+    {
+        if (!srouter::is_valid_sns(address))
+        {
+            try
+            {
+                srouter::NetworkAddress{address};
+            }
+            catch (...)
+            {
+                throw std::invalid_argument{
+                    "Invalid address: '{}' is not a valid SNS nor a valid network pubkey address"_format(address)};
+            }
+            callback(std::move(address), false);
+            return;
+        }
+
+        context->router->loop.call([address = std::move(address),
+                                    callback = std::move(callback),
+                                    &ep = context->router->session_endpoint()]() mutable {
+            ep.resolve_sns(
+                std::move(address),
+                [callback = std::move(callback)](
+                    std::optional<srouter::NetworkAddress> netaddr, bool assertive, std::chrono::milliseconds /*ttl*/) {
+                    std::optional<std::string> a;
+                    if (netaddr)
+                        a = netaddr->to_string();
+                    callback(std::move(a), !assertive);
+                });
+        });
     }
 
     std::optional<snode_path> SessionRouter::get_path_for_session(std::string_view remote)


### PR DESCRIPTION
This adds support for SNS resolution.

In doing so, I ran into a problem where the `on_connected` callback would fire before we can actually resolve anything through SNS, and so this also splits the "connected" status into two different concepts: "edge connected" (which is what was there already), and a new concept of "path connected", which means "edge connected" *and* an established inbound path.  This adds the needed pieces to implement that concept into Router.

Updates the libsession-router jank test to support ONS lookups (which also needs the above for the required proper connectivity detection).