### PR TITLE
Fix bullseye build

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -432,14 +432,13 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                   ],
                   jobs=4),
 
-  // Ubuntu
-  debian_pipeline('Ubuntu latest', docker_base + 'ubuntu-rolling'),
-  debian_pipeline('Ubuntu 24.04', docker_base + 'ubuntu-noble'),
-  debian_pipeline('Ubuntu 22.04', docker_base + 'ubuntu-jammy'),
+  debian_pipeline('Debian 11/bullseye',
+                  docker_base + 'debian-bullseye',
+                  deps=default_deps(remove='libcli11-dev')),
 
-  // Static ubuntu jammy amd64 build (upload to builds.lokinet.dev)
-  debian_pipeline('Ubuntu 22.04 static',
-                  docker_base + 'ubuntu-jammy',
+  // Static debian bullseye amd64 build (upload to builds.lokinet.dev)
+  debian_pipeline('Debian 11/bullseye static',
+                  docker_base + 'debian-bullseye',
                   deps=static_deps,
                   lto=true,
                   tests=false,
@@ -453,6 +452,11 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                     './contrib/ci/drone-static-upload.sh',
                   ]),
 
+
+  // Ubuntu
+  debian_pipeline('Ubuntu latest', docker_base + 'ubuntu-rolling'),
+  debian_pipeline('Ubuntu 24.04', docker_base + 'ubuntu-noble'),
+  debian_pipeline('Ubuntu 22.04', docker_base + 'ubuntu-jammy'),
 
   // cross compile targets
   // Aug 11: these are exhibiting some dumb failures in libsodium and external deps, TOFIX later

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -417,11 +417,21 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                   oxen_repo=[],
                   cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON'),
 
-  // Static debian 12 armhf (upload to builds.lokinet.dev)
-  debian_pipeline('Debian 12/bookworm static [armhf]',
-                  docker_base + 'debian-bookworm/arm32v7',
+  debian_pipeline('Debian 11/bullseye',
+                  docker_base + 'debian-bullseye',
+                  deps=default_deps(remove='libcli11-dev')),
+
+  // Static builds (uploaded to builds.lokinet.dev).  In general:
+  // - armhf and arm64 build on the oldest debian distro we support.  Technically there is some
+  //   arm64 ubuntu support, but the arm linux ecosystem seems to much more built on top of debian
+  //   rather than ubuntu.
+  // - amd64 we build on the oldest Debian *or* Ubuntu distro, so that it should work on that or
+  //   anything newer.
+  debian_pipeline('Static armhf (Debian 11/bullseye)',
+                  docker_base + 'debian-bullseye/arm32v7',
                   arch='arm64',
                   deps=static_deps,
+                  tests=false,
                   oxen_repo=[],
                   cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON ' +
                               '-DCMAKE_CXX_FLAGS="-march=armv7-a+fp -Wno-psabi" -DCMAKE_C_FLAGS="-march=armv7-a+fp" ' +
@@ -431,13 +441,21 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                     'UPLOAD_OS=linux-armhf ./contrib/ci/drone-static-upload.sh',
                   ],
                   jobs=4),
-
-  debian_pipeline('Debian 11/bullseye',
+  debian_pipeline('Static arm64 (Debian 11/bullseye)',
                   docker_base + 'debian-bullseye',
-                  deps=default_deps(remove='libcli11-dev')),
-
-  // Static debian bullseye amd64 build (upload to builds.lokinet.dev)
-  debian_pipeline('Debian 11/bullseye static',
+                  arch='arm64',
+                  deps=static_deps,
+                  tests=false,
+                  oxen_repo=[],
+                  cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON ' +
+                              '-DCMAKE_CXX_FLAGS="-march=armv8-a" -DCMAKE_C_FLAGS="-march=armv8-a" ' +
+                              '-DNATIVE_BUILD=OFF -DWITH_SYSTEMD=OFF -DWITH_BOOTSTRAP=OFF',
+                  extra_cmds=[
+                    './contrib/ci/drone-check-static-libs.sh',
+                    'UPLOAD_OS=linux-armhf ./contrib/ci/drone-static-upload.sh',
+                  ],
+                  jobs=4),
+  debian_pipeline('Static AMD64 (Debian 11/bullseye)',
                   docker_base + 'debian-bullseye',
                   deps=static_deps,
                   lto=true,

--- a/src/dns/encode.cpp
+++ b/src/dns/encode.cpp
@@ -129,7 +129,13 @@ namespace srouter::dns
 
         for (size_t pos = name.empty() ? std::string::npos : 0; pos != std::string_view::npos;)
         {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 11
+            // Workaround for gcc bug (fixed in gcc 11) which doesn't allow us to pass a string_view
+            // to unordered_map `find()` with a std::string key.
+            std::string check{name.substr(pos)};
+#else
             std::string_view check = name.substr(pos);
+#endif
             if (prev_names)
                 if (auto it = prev_names->find(check); it != prev_names->end())
                 {


### PR DESCRIPTION
Fixes compilation under gcc-10, and re-adds bullseye builds to CI so that this sort of thing gets caught.

Also updates CI to use bullseye (rather than Ubuntu 22.04) for the static build, as a bullseye is the oldest distro we support (and so a static build from there should work on everything else).