### PR TITLE
session-router-config improvements

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -89,7 +89,7 @@ if(SROUTER_HIVE)
 endif()
 
 
-system_or_submodule(CLI11 CLI11 CLI11::CLI11 CLI11>=2.3.0 CLI11)
+system_or_submodule(CLI11 CLI11 CLI11::CLI11 CLI11>=2.5.0 CLI11)
 
 
 if(SROUTER_PEERSTATS)

--- a/src/daemon/session-router-config.cpp
+++ b/src/daemon/session-router-config.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
         data_dir,
         "Specify an explicit data dir to use in the config file.  If not specified, data files will be stored in "
         "$HOME/.session-router");
-    cli.add_option("-t,--testnet", testnet, "Configure to use testnet instead of the main session-router network");
+    cli.add_flag("-t,--testnet", testnet, "Configure to use testnet instead of the main session-router network");
 
     cli.add_option(
            "filename",

--- a/src/daemon/session-router-config.cpp
+++ b/src/daemon/session-router-config.cpp
@@ -181,7 +181,7 @@ int main(int argc, char* argv[])
             check_overwrite(target);
             assert(client || hidden_svc || embedded || relay);
             std::string extra_ini = "";
-            if (hidden_svc || persist_key)
+            if (hidden_svc || (!relay && persist_key))
             {
                 Ed25519SecretKey skey;
                 auto key_file = target;

--- a/src/daemon/session-router-config.cpp
+++ b/src/daemon/session-router-config.cpp
@@ -9,6 +9,18 @@
 #include "util/logging.hpp"
 
 #include <CLI/CLI.hpp>
+#include <oxenmq/address.h>
+
+#include <charconv>
+#include <stdexcept>
+
+#ifndef _WIN32
+extern "C"
+{
+#include <sys/ioctl.h>
+#include <unistd.h>
+}
+#endif
 
 auto& logcat = srouter::log_global;
 
@@ -23,6 +35,27 @@ int main(int argc, char* argv[])
     CLI::App cli{
         "Session Router is a free, open source, private, decentralized, market-based sybil resistant "
         "and IP-based onion routing network"};
+
+    size_t wrap_width = 0;
+#ifndef _WIN32
+    if (struct winsize w{}; isatty(STDOUT_FILENO) && ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) != -1)
+        wrap_width = w.ws_col;
+    else
+#endif
+        if (const char* cols = std::getenv("COLUMNS"))
+    {
+        size_t c;
+        if (auto [ptr, ec] = std::from_chars(cols, cols + std::strlen(cols), c); ec == std::errc())
+            wrap_width = c;
+    }
+
+    if (wrap_width < 80)
+        wrap_width = 80;
+    --wrap_width;  // So that we aren't putting a character in the very last position which makes
+                   // some terminals add a blank line
+    cli.get_formatter()->column_width(30);
+    cli.get_formatter()->right_column_width(wrap_width - 30);
+    cli.get_formatter()->description_paragraph_width(wrap_width);
 
     bool version = false;
     bool client = false;

--- a/src/daemon/session-router-config.cpp
+++ b/src/daemon/session-router-config.cpp
@@ -71,6 +71,11 @@ int main(int argc, char* argv[])
     std::filesystem::path target;
     std::filesystem::path data_dir;
 
+    std::string listen_addr;
+    std::string public_ip;
+    uint16_t public_port = 0;
+    std::string oxend_rpc;
+
     // flags: boolean values in command_line_options struct
     cli.add_flag("--version", version, "Session Router version");
 
@@ -99,17 +104,44 @@ int main(int argc, char* argv[])
         force,
         "Force writing the given output config or key file even if it already exists, overwriting the existing "
         "file(s).");
-    cli.add_flag(
-        "-p,--persistent-key",
-        persist_key,
-        "Enable a persistent key file in the generated client or embedded config (this option is automatic for hidden "
-        "service configs).  The key will have the same name as the generated config but with a '.key' extension.");
+
     cli.add_option(
         "-d,--data-dir",
         data_dir,
         "Specify an explicit data dir to use in the config file.  If not specified, data files will be stored in "
         "$HOME/.session-router");
+
+    cli.add_option(
+        "--listen",
+        listen_addr,
+        "Specifies an address and/or port on which to bind for the [bind]:listen directive, in the form "
+        "'a.b.c.d:PORT', ':PORT', or 'a.b.c.d'");
     cli.add_flag("-t,--testnet", testnet, "Configure to use testnet instead of the main session-router network");
+
+    auto client_opts = cli.add_option_group(
+        "client",
+        "Client-specific options; these only have effect when generating a client/hidden service/embedded config.");
+    client_opts->add_flag(
+        "-p,--persistent-key",
+        persist_key,
+        "Enable a persistent key file in the generated client or embedded config (this option is automatic for hidden "
+        "service configs).  The key will have the same name as the generated config but with a '.key' extension.");
+
+    auto relay_opts =
+        cli.add_option_group("relay", "Relay-specific options; these only have effect when generating a relay config");
+    relay_opts->add_option(
+        "--public-ip",
+        public_ip,
+        "The public IPv4 address on which this session router relay is reachable (sets [router]:public-ip)");
+    relay_opts->add_option(
+        "--public-port",
+        public_port,
+        "The public IPv4 UDP port on which this session router relay is reachable (sets [router]:public-port)");
+    relay_opts->add_option(
+        "--oxend-rpc",
+        oxend_rpc,
+        "The oxend RPC socket used to communicate with this Session Node's oxend server ([oxend]:rpc); typically "
+        "ipc:///PATH/TO/oxend.sock");
 
     cli.add_option(
            "filename",
@@ -214,6 +246,55 @@ int main(int argc, char* argv[])
             {
                 extra_ini += "[paths]\ninbound-paths=8\n";
                 extra_ini += "[dns]\nlisten=\n";
+            }
+
+            if (!listen_addr.empty())
+            {
+                try
+                {
+                    auto addr = oxen::quic::Address::parse(listen_addr, 0);
+                    if (!addr.is_ipv4() && !addr.is_any_addr())
+                        throw std::invalid_argument{"IPv4 address required"};
+                }
+                catch (const std::exception& e)
+                {
+                    throw std::runtime_error{"Invalid --listen address: {}"_format(e.what())};
+                }
+                extra_ini += "[bind]\nlisten={}\n"_format(listen_addr);
+            }
+
+            if (relay)
+            {
+                if (!public_ip.empty())
+                {
+                    quic::ipv4 addr;
+                    try
+                    {
+                        addr = quic::ipv4{public_ip};
+                        quic::Address a{addr};
+                        if (!quic::Address{addr}.is_public_ip())
+                            throw std::invalid_argument{"{} is not publicly addressable"_format(addr)};
+                    }
+                    catch (const std::exception& e)
+                    {
+                        throw std::runtime_error{"Invalid --public-ip IPv4 address: {}"_format(e.what())};
+                    }
+                    extra_ini += "[router]\npublic-ip={}\n"_format(addr);
+                }
+                if (public_port > 0)
+                    extra_ini += "[router]\npublic-port={}\n"_format(public_port);
+                if (!oxend_rpc.empty())
+                {
+                    try
+                    {
+                        (void)oxenmq::address{oxend_rpc};
+                    }
+                    catch (const std::exception& e)
+                    {
+                        throw std::runtime_error{"Invalid --oxend-rpc value: {}"_format(e.what())};
+                    }
+                    extra_ini += "[oxend]\nrpc={}\n"_format(oxend_rpc);
+                }
             }
 
             if (!data_dir.empty())


### PR DESCRIPTION
- make `--help` output wrap nicely (requires CLI11 2.5 requirement bump)
- fix `--testnet` expected an argument
- ignore persistent key option for relay configs
- add some common relay-specific settings