### PR TITLE
Redo tun auto-selection to retry up to 50 times

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -672,6 +672,31 @@ namespace srouter
                 }
             });
 
+        conf.add_options_validator([this] {
+            if (!_reserved_local_ipv4.empty())
+            {
+                if (ipv4_autoselect())
+                    throw std::invalid_argument{"[network]:mapaddr requires an IPv4 range for [network]:ifaddr"};
+
+                for (const auto& [netaddr, ip] : _reserved_local_ipv4)
+                    if (!_local_ip_net->contains(ip))
+                        throw std::invalid_argument{
+                            "Invalid [network]:mapaddr mapping: {} is not within the configured IPv4 range {}"_format(
+                                ip, *_local_ip_net)};
+            }
+            if (!_reserved_local_ipv6.empty())
+            {
+                if (ipv6_autoselect())
+                    throw std::invalid_argument{"[network]:mapaddr requires an IPv6 range for [network]:ifaddr"};
+
+                for (const auto& [netaddr, ip] : _reserved_local_ipv6)
+                    if (!_local_ipv6_net->contains(ip))
+                        throw std::invalid_argument{
+                            "Invalid [network]:mapaddr mapping: {} is not within the configured IPv6 range {}"_format(
+                                ip, *_local_ipv6_net)};
+            }
+        });
+
         conf.define_option<int>(
             "network",
             "expired-address-cache",

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -185,6 +185,9 @@ namespace srouter
         std::optional<ipv4_net> _local_ip_net;
         std::optional<ipv6_net> _local_ipv6_net;
 
+        bool ipv4_autoselect() const { return !_local_ip_net || !_local_ip_net->ip.addr; }
+        bool ipv6_autoselect() const { return !_local_ipv6_net || !(_local_ipv6_net->ip.hi || _local_ipv6_net->ip.lo); }
+
         // Remote exit or hidden service addresses mapped to fixed local IP addresses
         // TODO:
         //  - load directly into TunEndpoint mapping

--- a/src/handlers/tun.cpp
+++ b/src/handlers/tun.cpp
@@ -4,6 +4,7 @@
 #include <oxenc/base32z.h>
 #include <oxenc/endian.h>
 
+#include <chrono>
 #include <span>
 #include <variant>
 #ifndef _WIN32
@@ -39,12 +40,32 @@ namespace srouter::handlers
 
         _if_name = net_conf._if_name.value_or("");
 
-        // These should have been assigned by Router before this:
+        // These should have been assigned by Router before this; they might, however, still be
+        // quad-0 or :: to indicate autoselection of an unused range.
         assert(net_conf._local_ip_net);
         assert(net_conf._local_ipv6_net);
 
-        _local_net = *net_conf._local_ip_net;
-        _local_ipv6_net = *net_conf._local_ipv6_net;
+        vpn::InterfaceInfo info;
+        info.ifname = _if_name;
+        info.addrs.emplace_back(*net_conf._local_ip_net);
+        info.addrs.emplace_back(*net_conf._local_ipv6_net);
+
+        log::debug(logcat, "{} setting up network...", name());
+
+        _net_if = router().vpn_platform()->create_interface(std::move(info), &_router);
+        _if_name = _net_if->interface_info().ifname;
+
+        log::info(logcat, "{} got network interface:{}", name(), _if_name);
+
+        // Load the addresses out of the interface, *not* the config, because the interface
+        // construction will have done auto-selection for any 0 addresses:
+        for (auto& addr : _net_if->interface_info().addrs)
+        {
+            if (auto* n4 = std::get_if<ipv4_net>(&addr))
+                _local_net = *n4;
+            else
+                _local_ipv6_net = std::get<ipv6_net>(addr);
+        }
 
 #if 0
         if (net_conf.addr_map_persist_file)
@@ -92,21 +113,6 @@ namespace srouter::handlers
         log::debug(logcat, "Tun constructing IPRange iterator on local networks: {}, {}", _local_net, _local_ipv6_net);
         _local_range_iterator = IPRangeIterator{_local_net};
         _local_ipv6_range_iterator = IPv6RangeIterator{_local_ipv6_net};
-
-        vpn::InterfaceInfo info;
-        info.ifname = _if_name;
-        info.addrs.emplace_back(_local_net);
-        info.addrs.emplace_back(_local_ipv6_net);
-
-        log::debug(logcat, "{} setting up network...", name());
-
-        log::info(logcat, "{} using IPv4 address range {}", name(), _local_net);
-        log::info(logcat, "{} using IPv6 address range {}", name(), _local_ipv6_net);
-
-        _net_if = router().vpn_platform()->create_interface(std::move(info), &_router);
-        _if_name = _net_if->interface_info().ifname;
-
-        log::info(logcat, "{} got network interface:{}", name(), _if_name);
     }
 
     static const auto random_snode = "random.{}"_format(RELAY_TLD);

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -371,44 +371,45 @@ namespace srouter
                 netconf._if_name = net()->find_free_tun(suggest);
             }
 
-            if (!(netconf._local_ip_net && netconf._local_ip_net->ip.addr))
+            if (netconf.ipv4_autoselect())
             {
-                // If we are running as a service node *and* don't have an explicit local ip range
-                // set, then we introduce a small random delay here in startup, to help avoid cases
-                // where multiple session-routers start at the same time (e.g. in a multi-SN setup)
-                // and race to assign the same "free" IP range on the tun device, but end up with
-                // duplicate ranges on multiple tun devices.  We detect (and abort startup) if that
-                // happens, but the extra sleep here spaces them out to lower the chance of hitting
-                // that.
-                if (is_service_node)
-                    std::this_thread::sleep_for(
-                        uniform_duration_distribution<std::chrono::nanoseconds>{0ms, 25ms}(csrng));
+                if (!netconf._reserved_local_ipv4.empty())
+                    throw std::runtime_error{"[network]:mapaddr cannot be used with automatic IPv4 range selection"};
+                log::info(logcat, "Session Router IPv4 local network will be auto-selected");
 
-                if (auto maybe = net()->find_free_ipv4_net(netconf._local_ip_net ? netconf._local_ip_net->mask : 16))
-                    netconf._local_ip_net = std::move(*maybe);
-                else
-                    throw std::runtime_error("cannot find free IPv4 address range!");
+                if (!netconf._local_ip_net)
+                    netconf._local_ip_net.emplace().mask = 16;
             }
-            log::info(logcat, "Session Router IPv4 local network is {}", *netconf._local_ip_net);
-
-            if (!netconf._local_ipv6_net || (!netconf._local_ipv6_net->ip.hi && !netconf._local_ipv6_net->ip.lo))
+            else
             {
-                if (auto maybe =
-                        net()->find_free_ipv6_net(netconf._local_ipv6_net ? netconf._local_ipv6_net->mask : 64))
-                    netconf._local_ipv6_net = std::move(*maybe);
-                else
-                    throw std::runtime_error("cannot find free IPv6 address range!");
-            }
-            log::info(logcat, "Session Router IPv6 local network is {}", *netconf._local_ipv6_net);
+                assert(netconf._local_ip_net);
+                log::info(logcat, "Session Router IPv4 local network is {}", *netconf._local_ip_net);
 
-            // Make sure any reserved addresses are within our local network range:
-            std::erase_if(netconf._reserved_local_ipv4, [&netconf](const auto& addr_ip) {
-                return !netconf._local_ip_net->contains(addr_ip.second);
-            });
-            if (netconf._local_ipv6_net)
+                // Config should have already verified this, but just in case:
+                std::erase_if(netconf._reserved_local_ipv4, [&netconf](const auto& addr_ip) {
+                    return !netconf._local_ip_net->contains(addr_ip.second);
+                });
+            }
+
+            if (netconf.ipv6_autoselect())
+            {
+                if (!netconf._reserved_local_ipv6.empty())
+                    throw std::runtime_error{"[network]:mapaddr cannot be used with automatic IPv4 range selection"};
+                log::info(logcat, "Session Router IPv6 local network will be auto-selected");
+
+                if (!netconf._local_ipv6_net)
+                    netconf._local_ipv6_net.emplace().mask = 64;
+            }
+            else
+            {
+                assert(netconf._local_ipv6_net);
+                log::info(logcat, "Session Router IPv6 local network is {}", *netconf._local_ipv6_net);
+
+                // Config should have already verified this, but just in case:
                 std::erase_if(netconf._reserved_local_ipv6, [&netconf](const auto& addr_ip) {
                     return !netconf._local_ipv6_net->contains(addr_ip.second);
                 });
+            }
         }
 
         if (not is_service_node)
@@ -554,6 +555,9 @@ namespace srouter
 #else
             log::debug(logcat, "Initializing TUN device");
             _tun = _loop->make_shared<handlers::TunEndpoint>(*this);
+
+            log::info(logcat, "Session Router IPv4 local network is {}", _tun->get_ipv4_network());
+            log::info(logcat, "Session Router IPv6 local network is {}", _tun->get_ipv6_network());
 
             // only (full) clients should have DNS, relays have no need for it
             if (!is_service_node)

--- a/src/vpn/linux.hpp
+++ b/src/vpn/linux.hpp
@@ -23,8 +23,6 @@ namespace srouter::vpn
 {
     static auto logcat = log::Cat("vpn.linux");
 
-    inline constexpr std::array<ipv6, 4> if_ipv6_addrs{ipv6{}, ipv6{0x4000}, ipv6{0x8000}, ipv6{0xc000}};
-
     struct in6_ifreq
     {
         in6_addr addr;
@@ -103,11 +101,18 @@ namespace srouter::vpn
             if (_info.addrs.empty())
                 throw std::runtime_error{"Cannot set up a TUN interface with no addresses!"};
 
+            auto net_plat = srouter::net::Platform::Default_ptr();
+            assert(net_plat);
+
             std::list<std::string> addr_strings;
+
+            // Counts the number of consecutive failures to apply an auto-selected unused range
+            int auto_failures = 0;
+
             // Add addresses to the tun interface:
-            for (const auto& ifaddr : _info.addrs)
+            for (auto it = _info.addrs.begin(); it != _info.addrs.end();)
             {
-                log::debug(logcat, "Adding address {} to {}", ifaddr, _info.ifname);
+                auto& ifaddr = *it;
                 struct
                 {
                     nlmsghdr header;
@@ -121,8 +126,23 @@ namespace srouter::vpn
                 request.header.nlmsg_type = RTM_NEWADDR;
                 request.content.ifa_index = _info.index;
 
-                if (auto* n4 = std::get_if<ipv4_net>(&ifaddr))
+                const ipv4_net* n4 = std::get_if<ipv4_net>(&ifaddr);
+                const ipv6_net* n6 = nullptr;
+
+                std::optional<std::variant<ipv4_net, ipv6_net>> auto_addr;
+                if (n4)
                 {
+                    if (n4->ip == ipv4{})
+                    {  // "0" IP means auto-select a free range
+                        auto n = net_plat->find_free_ipv4_net(n4->mask);
+                        if (!n)
+                            throw std::runtime_error{
+                                "Could not find any unused private IPv4 /{} range for auto-selection"_format(n4->mask)};
+
+                        auto_addr = std::move(*n);
+                        n4 = &std::get<ipv4_net>(*auto_addr);
+                    }
+
                     addr_strings.push_back(n4->to_string());
                     request.content.ifa_family = AF_INET;
                     request.content.ifa_prefixlen = n4->mask;
@@ -140,66 +160,118 @@ namespace srouter::vpn
                 }
                 else
                 {
-                    auto& n6 = std::get<ipv6_net>(ifaddr);
-                    addr_strings.push_back(n6.to_string());
+                    n6 = &std::get<ipv6_net>(ifaddr);
+                    if (n6->ip == ipv6{})
+                    {  // "0" IP means auto-select a free range
+                        auto n = net_plat->find_free_ipv6_net(n6->mask);
+                        if (!n)
+                            throw std::runtime_error{
+                                "Could not find any unused private IPv6 /{} range for auto-selection"_format(n6->mask)};
+
+                        auto_addr = std::move(*n);
+                        n6 = &std::get<ipv6_net>(*auto_addr);
+                    }
+
+                    addr_strings.push_back(n6->to_string());
                     request.content.ifa_family = AF_INET6;
-                    request.content.ifa_prefixlen = n6.mask;
+                    request.content.ifa_prefixlen = n6->mask;
                     auto* req_attr = IFA_RTA(&request.content);
                     req_attr->rta_type = IFA_LOCAL;
                     req_attr->rta_len = RTA_LENGTH(sizeof(in6_addr));
                     request.header.nlmsg_len += req_attr->rta_len;
                     char* addr_data = static_cast<char*>(RTA_DATA(req_attr));
-                    oxenc::write_host_as_big(n6.ip.hi, addr_data);
-                    oxenc::write_host_as_big(n6.ip.lo, addr_data + 8);
+                    oxenc::write_host_as_big(n6->ip.hi, addr_data);
+                    oxenc::write_host_as_big(n6->ip.lo, addr_data + 8);
 
                     req_attr = RTA_NEXT(req_attr, buf_avail);
                     req_attr->rta_type = IFA_ADDRESS;
                     req_attr->rta_len = RTA_LENGTH(sizeof(in6_addr));
                     request.header.nlmsg_len += req_attr->rta_len;
                     addr_data = static_cast<char*>(RTA_DATA(req_attr));
-                    oxenc::write_host_as_big(n6.ip.hi, addr_data);
-                    oxenc::write_host_as_big(n6.ip.lo, addr_data + 8);
+                    oxenc::write_host_as_big(n6->ip.hi, addr_data);
+                    oxenc::write_host_as_big(n6->ip.lo, addr_data + 8);
                 }
 
                 if (auto err = nl_submit(nlfd, request))
                     throw std::runtime_error{
                         "Failed to add address {} to {}: {}"_format(addr_strings.back(), _info.ifname, *err)};
-            }
 
-            // Check to make sure that we are the *only* interface with our configured addresses, in
-            // case some other session-router raced us for it.
-            ifaddrs* ia;
-            if (0 != getifaddrs(&ia))
-                throw std::runtime_error{"Failed to query network addresses to check for duplicates"};
+                // Adding a conflicting address does not fail, and so we need to go query all the
+                // addresses on the system to see if the same address exists on any *other*
+                // interface and if so, either retry (if we are using auto-selection) or error out.
 
-            for (; ia; ia = ia->ifa_next)
-            {
-                if (ia->ifa_name == _info.ifname)
-                    continue;  // This is our own one that we just added
+                ifaddrs* ia_head;
+                if (0 != getifaddrs(&ia_head))
+                    throw std::runtime_error{"Failed to query network addresses to check for duplicates"};
 
-                for (const auto& a : _info.addrs)
+                std::string problem;
+                for (ifaddrs* ia = ia_head; ia && problem.empty(); ia = ia->ifa_next)
                 {
-                    if (auto* v4 = std::get_if<ipv4_net>(&a);
-                        v4 and ia->ifa_addr and ia->ifa_addr->sa_family == AF_INET)
+                    if (ia->ifa_name == _info.ifname)
+                        continue;  // This is our own one that we just added
+
+                    if (!ia->ifa_addr)
+                        continue;  // Dunno
+
+                    if (n4 && ia->ifa_addr->sa_family == AF_INET)
                     {
                         ipv4 found4{reinterpret_cast<sockaddr_in*>(ia->ifa_addr)->sin_addr};
-                        if (v4->contains(found4))
-                            throw std::runtime_error{
+                        if (n4->contains(found4))
+                            problem =
                                 "TUN setup {} with address {} failed: found conflicting IP {} on network interface {}"_format(
-                                    _info.ifname, *v4, found4, ia->ifa_name)};
+                                    _info.ifname, *n4, found4, ia->ifa_name);
                     }
-                    else if (auto* v6 = std::get_if<ipv6_net>(&a);
-                             v6 and ia->ifa_addr and ia->ifa_addr->sa_family == AF_INET6)
+                    else if (n6 && ia->ifa_addr && ia->ifa_addr->sa_family == AF_INET6)
                     {
                         ipv6 found6{reinterpret_cast<sockaddr_in6*>(ia->ifa_addr)->sin6_addr};
-                        if (v6->contains(found6))
-                            throw std::runtime_error{
+                        if (n6->contains(found6))
+                            problem =
                                 "TUN setup {} @ {} failed: found conflicting IP {} on network interface {}"_format(
-                                    _info.ifname, *v6, found6, ia->ifa_name)};
+                                    _info.ifname, *n6, found6, ia->ifa_name);
                     }
                 }
+                freeifaddrs(ia_head);
+
+                if (!problem.empty())
+                {
+                    if (auto_addr && auto_failures++ < 50)
+                    {
+                        log::warning(
+                            logcat,
+                            "Address auto-selection failure: {}; removing address and retrying auto-selection",
+                            problem);
+
+                        // The request to delete the address is identical, aside from the nlmsg_type and flags:
+                        request.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+                        request.header.nlmsg_type = RTM_DELADDR;
+                        if (auto err = nl_submit(nlfd, request))
+                            throw std::runtime_error{"Failed to delete address {} from {}: {}"_format(
+                                addr_strings.back(), _info.ifname, *err)};
+
+                        addr_strings.pop_back();
+
+                        // We add a tiny random delay here so that if we are racing with another SR
+                        // process trying to auto-select a range we are more likely to have one or
+                        // the other succeed and "win" a range without getting both stuck racing
+                        // again trying to use the same address again on the next iteration.
+                        std::this_thread::sleep_for(
+                            uniform_duration_distribution<std::chrono::nanoseconds>{0ms, 25ms}(csrng));
+
+                        continue;  // *Without* it++
+                    }
+
+                    throw std::runtime_error{problem};
+                }
+
+                if (auto_addr)
+                {
+                    log::info(logcat, "Auto-selected tun range {}", addr_strings.back());
+                    ifaddr = std::move(*auto_addr);
+                    auto_failures = 0;  // Reset in case the next address also needs auto-selection
+                }
+
+                ++it;
             }
-            freeifaddrs(ia);
 
             // Bring up the tun device:
             {


### PR DESCRIPTION
Currently we find a free IP address for the tun during configuration, and then actually try to assign that much later in Router startup.

This can easily race with other session-router processes, causing them to fail startup, and then have to get restarted (e.g. by systemd).

This is annoying, and this commit fixes it by moving the auto-selection into the interface creation code itself, along with a retry loop in case of conflicts to largely avoid such failed startups.  Essentially, now, if the interface creation gets a 0 address, that means to auto-select a range rather than us always passing in a specific range to try.

To deal with an issue of mapaddr config values getting processed during config handling (where previously they were depending on the auto-selected range), this now imposes a new config rule: any specified mapaddrs require an explicit tun range and fail a new config check if there is no explicit tun range, or if the mapped addresses are not inside that tun range.