### PR TITLE
defer session removal after close for iteration safety

### DIFF
--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -117,10 +117,10 @@ namespace srouter::handlers
 
         // defer this in case we're in the middle of iterating the container(s)
         // capture a weak_ptr to the session so that if for whatever reason
-        router.loop.call_soon([this, remote, weak = std::weak_ptr(s)]() {
+        router.loop.call_soon([this, weak = std::weak_ptr(s)]() {
             if (auto shared = weak.lock())
             {
-                if (auto it = _sessions.find(remote); it != _sessions.end())
+                if (auto it = _sessions.find(shared->remote()); it != _sessions.end())
                 {
                     if (shared != it->second)
                         return;  // session is already gone

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -115,12 +115,15 @@ namespace srouter::handlers
             tun->expire(remote);
 #endif
 
-        if (auto it = _sessions.find(remote); it != _sessions.end())
-        {
-            if (auto& s = it->second)
-                _session_tags.erase(s->inbound_tag());
-            _sessions.erase(it);
-        }
+        // defer this in case we're in the middle of iterating the container(s)
+        router.loop.call_soon([this, remote]() {
+            if (auto it = _sessions.find(remote); it != _sessions.end())
+            {
+                if (auto& s = it->second)
+                    _session_tags.erase(s->inbound_tag());
+                _sessions.erase(it);
+            }
+        });
     }
 
     bool SessionEndpoint::close_session(NetworkAddress remote, bool send_close)

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -100,7 +100,7 @@ namespace srouter::handlers
         return stats;
     }
 
-    void SessionEndpoint::close_session(std::shared_ptr<session::Session>& s, bool send_close)
+    void SessionEndpoint::close_session(const std::shared_ptr<session::Session>& s, bool send_close)
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
@@ -116,12 +116,19 @@ namespace srouter::handlers
 #endif
 
         // defer this in case we're in the middle of iterating the container(s)
-        router.loop.call_soon([this, remote]() {
-            if (auto it = _sessions.find(remote); it != _sessions.end())
+        // capture a weak_ptr to the session so that if for whatever reason
+        router.loop.call_soon([this, remote, weak = std::weak_ptr(s)]() {
+            if (auto shared = weak.lock())
             {
-                if (auto& s = it->second)
-                    _session_tags.erase(s->inbound_tag());
-                _sessions.erase(it);
+                if (auto it = _sessions.find(remote); it != _sessions.end())
+                {
+                    if (shared != it->second)
+                        return;  // session is already gone
+
+                    if (auto& s = it->second)
+                        _session_tags.erase(s->inbound_tag());
+                    _sessions.erase(it);
+                }
             }
         });
     }
@@ -1234,6 +1241,12 @@ namespace srouter::handlers
         // FIXME: If the initiator does not get our response in time, they will try again
         // to establish a session; in that case we should replace what we have.
         auto& s = _sessions[new_session->remote()];
+
+        // if there was already a session to the remote, we're trampling it, so clear it from
+        // _session_tags
+        if (s)
+            _session_tags.erase(s->inbound_tag());
+
         auto* sptr = new_session.get();
         s = std::move(new_session);
         _session_tags[s->inbound_tag()] = s;

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -58,7 +58,7 @@ namespace srouter
 
             std::optional<std::string_view> fetch_auth_token(const NetworkAddress& remote) const;
 
-            void close_session(std::shared_ptr<session::Session>& s, bool send_close);
+            void close_session(const std::shared_ptr<session::Session>& s, bool send_close);
 
             void on_path_build_failure(int64_t build_id, path::Path* path, bool timeout) override;
             void on_path_build_success(int64_t build_id, path::Path& p) override;


### PR DESCRIPTION
Sometimes `close_session` is called while iterating sessions, so removing that session from the container breaks.  Instead, this will defer the removal to a later call on the event loop.  It's possible keeping a list of sessions to remove when iterating and removing them after would be better, but more complex.