### PR TITLE
Make Router use libquic JobQueue

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 
 
 set(LIBQUIC_BUILD_TESTS OFF CACHE BOOL "")
-system_or_submodule(OXENQUIC quic oxen::quic liboxenquic>=1.7.1 oxen-libquic)
+system_or_submodule(OXENQUIC quic oxen::quic liboxenquic>=1.8.0 oxen-libquic)
 
 
 # libcrypt defaults, only on with macos and non static linux

--- a/include/session/router_context.hpp
+++ b/include/session/router_context.hpp
@@ -27,7 +27,7 @@ namespace srouter
     // TODO FIXME this class seems unnecessary, we should get rid of it.
     struct Context
     {
-        std::unique_ptr<Router> router;
+        std::shared_ptr<Router> router;
 
         explicit Context(bool embedded);
         ~Context();

--- a/include/session/router_context.hpp
+++ b/include/session/router_context.hpp
@@ -29,6 +29,11 @@ namespace srouter
     {
         std::shared_ptr<Router> router;
 
+        // If we are not given an event loop, we must own it so that Router does not own its own
+        // loop and yet queue its destructor onto said loop, as the Router and Loop destructors
+        // would deadlock.
+        std::shared_ptr<oxen::quic::Loop> router_loop;
+
         explicit Context(bool embedded);
         ~Context();
 

--- a/include/session/router_context.hpp
+++ b/include/session/router_context.hpp
@@ -27,47 +27,38 @@ namespace srouter
     // TODO FIXME this class seems unnecessary, we should get rid of it.
     struct Context
     {
-        std::shared_ptr<Router> router;
+        Router* router;
 
-        // If we are not given an event loop, we must own it so that Router does not own its own
-        // loop and yet queue its destructor onto said loop, as the Router and Loop destructors
-        // would deadlock.
-        std::shared_ptr<oxen::quic::Loop> router_loop;
-
-        explicit Context(bool embedded);
+        explicit Context(bool embedded, Config conf, std::shared_ptr<oxen::quic::Loop> loop = nullptr);
         ~Context();
-
-        // Starts Session Router; returns as soon as Session Router is up and running (or throws if startup
-        // fails).  The loop may be provided in order to use an existing loop, but otherwise a new
-        // one will be started.
-        void start(Config conf, std::shared_ptr<oxen::quic::Loop> loop = nullptr);
-
-        // Waits for Session Router to finish.  Note that this does not *trigger* such a shutdown; for that
-        // you would call `stop()` before this.
-        void wait();
 
         // Call this to deliver a signal, such as SIGTERM or SIGINT to stop Session Router if currently
         // running.  (This can be called from any thread).
         void signal(int sig);
 
-        // Initiates Session Router shutdown, and returns immediately (without waiting for shutdown).  Call
-        // `wait()` after this if you also want to wait for shutdown to complete.
-        void stop();
-
-        bool is_up() const;
-
-        bool is_stopping() const;
-
-        // Returns true if Session Router has stopped and `wait()` needs to be called to finish
-        // destruction.
-        bool is_waiting() const;
-
+        // Anything calling this is responsible for not doing so during or after this object's destructor.
         bool looks_alive() const;
+
+        bool is_running() const;
+
+        // Blocks the current thread until the Router object has shut down.
+        void wait();
 
         int androidFD = -1;
 
       private:
+        // Starts Session Router; returns as soon as Session Router is up and running (or throws if startup
+        // fails).  The loop may be provided in order to use an existing loop, but otherwise a new
+        // one will be started.
+        void start(Config conf, std::shared_ptr<oxen::quic::Loop> loop = nullptr);
+
+        void stop();
+
+        // We keep a copy of the event loop to ensure that it exists through the lifetime of Router
+        std::shared_ptr<oxen::quic::Loop> router_loop;
+
         bool embedded;
+        std::atomic<bool> running{true};
         std::future<void> lifetime_waiter;
     };
 }  // namespace srouter

--- a/src/consensus/reachability_testing.cpp
+++ b/src/consensus/reachability_testing.cpp
@@ -25,8 +25,8 @@ namespace srouter::consensus
         else
         {
             log::debug(logcat, "Starting reachability testing tickers");
-            ticker = router.loop.call_every(TEST_INTERVAL, [this] { tick(); });
-            whine_ticker = router.loop.call_every(30s, [this] { check_incoming_tests(); });
+            ticker = router.loop().call_every(TEST_INTERVAL, [this] { tick(); });
+            whine_ticker = router.loop().call_every(30s, [this] { check_incoming_tests(); });
         }
     }
 
@@ -88,7 +88,7 @@ namespace srouter::consensus
                     auto conn = weak_conn.lock();
                     if (conn)
                         conn->close_connection();
-                    router.loop.call_soon([this, rid, prev_fails, m = std::move(m)] {
+                    router._jq->call_soon([this, rid, prev_fails, m = std::move(m)] {
                         if (m)
                         {
                             if (prev_fails)

--- a/src/contact/contactdb.cpp
+++ b/src/contact/contactdb.cpp
@@ -1,7 +1,6 @@
 #include "contactdb.hpp"
 
 #include "constants/path.hpp"
-#include "crypto/crypto.hpp"
 #include "router/router.hpp"
 #include "util/logging/buffer.hpp"
 
@@ -29,7 +28,7 @@ namespace srouter
 
     void ContactDB::start_tickers()
     {
-        _purge_ticker = _router.loop.call_every(30s, [this]() { purge_ccs(); }, true);
+        _purge_ticker = _router.loop().call_every(30s, [this]() { purge_ccs(); }, true);
     }
 
     void ContactDB::purge_ccs(sys_ms now)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,14 +21,11 @@ namespace srouter
 {
     static auto logcat = log::Cat("context");
 
-    // Defaulted here because the header doesn't have visibility of the unique_ptr destructors.
-    Context::~Context() = default;
+    bool Context::looks_alive() const { return router->looks_alive(); }
 
-    bool Context::is_up() const { return router && router->is_running(); }
+    bool Context::is_running() const { return running.load(); }
 
-    bool Context::is_waiting() const { return router && !router->is_running(); }
-
-    bool Context::looks_alive() const { return router && router->looks_alive(); }
+    void Context::wait() { lifetime_waiter.get(); }
 
     void Context::start(Config conf, std::shared_ptr<oxen::quic::Loop> loop)
     {
@@ -44,11 +41,11 @@ namespace srouter
             log::debug(logcat, "Initializing event loop...");
 
             loop = std::make_shared<quic::Loop>();
-            router_loop = loop;
             assert(loop->call_get([] { return 42; }) == 42);
 
             log::debug(logcat, "Event loop initialized!");
         }
+        router_loop = loop;
 
         std::promise<void> done_promise;
         lifetime_waiter = done_promise.get_future();
@@ -67,7 +64,7 @@ namespace srouter
         log::debug(logcat, "Starting main router...");
         try
         {
-            router = loop->make_shared<Router>(std::move(conf), loop, std::move(plat), std::move(done_promise));
+            router = new Router{std::move(conf), loop, std::move(plat), std::move(done_promise)};
         }
         catch (const std::exception& e)
         {
@@ -76,24 +73,26 @@ namespace srouter
         }
     }
 
-    void Context::wait()
-    {
-        if (!router)
-            return;
-        lifetime_waiter.get();
-        assert(router.use_count() == 1);
-        router.reset();
-        router_loop.reset();  // in the event we own the loop, destroy it *after* Router
-    }
-
     void Context::stop()
     {
-        if (!router)
+        if (!running.exchange(false))
             return;
+
         router->stop();
     }
 
-    bool Context::is_stopping() const { return router && router->is_stopping(); }
+    Context::~Context()
+    {
+        // if stop() has not been called yet, we wait on the future.  If something else calls stop,
+        // it is expected to wait on the future.
+        if (running.exchange(false))
+        {
+            stop();
+            wait();
+        }
+
+        router_loop->call_get([this]() { delete router; });
+    }
 
     void Context::signal(int sig)
     {
@@ -109,13 +108,14 @@ namespace srouter
         }
     }
 
-    Context::Context(bool embedded) : embedded{embedded}
+    Context::Context(bool embedded, Config conf, std::shared_ptr<oxen::quic::Loop> loop) : embedded{embedded}
     {
 #ifndef SROUTER_EMBEDDED_ONLY
         // service_manager is a global and context isnt
         if (!embedded)
             srouter::sys::service_manager->give_context(this);
 #endif
+        start(std::move(conf), std::move(loop));
     }
 
 }  // namespace srouter

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -44,6 +44,7 @@ namespace srouter
             log::debug(logcat, "Initializing event loop...");
 
             loop = std::make_shared<quic::Loop>();
+            router_loop = loop;
             assert(loop->call_get([] { return 42; }) == 42);
 
             log::debug(logcat, "Event loop initialized!");
@@ -80,7 +81,9 @@ namespace srouter
         if (!router)
             return;
         lifetime_waiter.get();
+        assert(router.use_count() == 1);
         router.reset();
+        router_loop.reset();  // in the event we own the loop, destroy it *after* Router
     }
 
     void Context::stop()

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -66,8 +66,7 @@ namespace srouter
         log::debug(logcat, "Starting main router...");
         try
         {
-            router =
-                std::make_unique<Router>(std::move(conf), std::move(loop), std::move(plat), std::move(done_promise));
+            router = loop->make_shared<Router>(std::move(conf), loop, std::move(plat), std::move(done_promise));
         }
         catch (const std::exception& e)
         {

--- a/src/daemon/session_router.cpp
+++ b/src/daemon/session_router.cpp
@@ -421,7 +421,7 @@ namespace
             while (ftr.wait_for(1s) != std::future_status::ready)
             {
                 // do periodic non Session Router related tasks here
-                if (ctx and ctx->is_up() and not ctx->looks_alive())
+                if (ctx and ctx->is_running() and not ctx->looks_alive())
                 {
                     auto deadlock_cat = srouter::log::Cat("deadlock");
                     srouter::log::critical(deadlock_cat, "Router has deadlocked!");
@@ -467,13 +467,11 @@ namespace
                 conf->logging.levels += log_level;
             }
 
-            ctx.emplace(/*embedded=*/false);
+            ctx.emplace(/*embedded=*/false, std::move(*conf));
 
             signal(SIGINT, handle_signal);
             signal(SIGTERM, handle_signal);
             signal(SIGKILL, handle_signal);
-
-            ctx->start(std::move(*conf));
         }
         catch (srouter::util::bind_socket_error& ex)
         {

--- a/src/dns/listener.cpp
+++ b/src/dns/listener.cpp
@@ -44,7 +44,7 @@ namespace srouter::dns
             evconnlistener_free(e);
     }
 
-    Listener::Listener(Router& router, const quic::Address& bind) : _handler{router} { listen(router.loop, bind); }
+    Listener::Listener(Router& router, const quic::Address& bind) : _handler{router} { listen(router.loop(), bind); }
 
     struct Listener::udp_socket_helper
     {

--- a/src/dns/unbound.cpp
+++ b/src/dns/unbound.cpp
@@ -13,7 +13,7 @@ namespace srouter::dns
 
     void Unbound::ub_ctx_deleter::operator()(ub_ctx* ctx) { ub_ctx_delete(ctx); }
 
-    Unbound::Unbound(Router& router) : _loop{router.loop}
+    Unbound::Unbound(Router& router) : _loop{*router._loop}
     {
         auto* ctx = ub_ctx_create_event(_loop.get_event_base());
         if (!ctx)

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -117,7 +117,7 @@ namespace srouter::handlers
 
         // defer this in case we're in the middle of iterating the container(s)
         // capture a weak_ptr to the session so that if for whatever reason
-        router.loop.call_soon([this, weak = std::weak_ptr(s)]() {
+        router._jq->call_soon([this, weak = std::weak_ptr(s)]() {
             if (auto shared = weak.lock())
             {
                 if (auto it = _sessions.find(shared->remote()); it != _sessions.end())
@@ -1362,7 +1362,7 @@ namespace srouter::handlers
         std::function<void(session::Session& session)> on_attempted,
         std::optional<std::chrono::milliseconds> timeout)
     {
-        return router.loop.call_get([this, &remote, &on_attempted, &timeout] {
+        return router._jq->call_get([this, &remote, &on_attempted, &timeout] {
             std::shared_ptr<session::Session> s{nullptr};
             if (_sessions.contains(remote))
                 s = _sessions[remote];
@@ -1388,10 +1388,10 @@ namespace srouter::handlers
                 try
                 {
                     if (remote.client())
-                        s = router.loop.make_shared<session::OutboundClientSession>(
+                        s = router._jq->make_shared<session::OutboundClientSession>(
                             remote, *this, tag, std::move(on_attempted), timeout);
                     else
-                        s = router.loop.make_shared<session::OutboundRelaySession>(
+                        s = router._jq->make_shared<session::OutboundRelaySession>(
                             remote, *this, tag, std::move(on_attempted), timeout);
                     _session_tags.emplace(tag, s);
                     _sessions[remote] = s;
@@ -1424,7 +1424,7 @@ namespace srouter::handlers
     std::pair<uint16_t, std::shared_ptr<session::Session>> SessionEndpoint::map_udp_remote_port(
         const NetworkAddress& remote, uint16_t port)
     {
-        return router.loop.call_get([&] {
+        return router._jq->call_get([&] {
             // Port selection: we pick something random in the 49152-60000 range to start from, as
             // that range (up to 60999) is common to all modern OSes for ephemeral addresses, and so
             // at least our first thousand ports will look like a normal random ephemeral port.
@@ -1442,7 +1442,7 @@ namespace srouter::handlers
             if (!existing)
 
                 udp_handle = std::make_unique<quic::UDPSocket>(
-                    router.loop.get_event_base(),
+                    router.loop().get_event_base(),
                     quic::Address{"::1", 0},
                     /*gso=*/false,
                     [this, target](quic::Packet&& pkt) {

--- a/src/handlers/tun.cpp
+++ b/src/handlers/tun.cpp
@@ -428,7 +428,7 @@ namespace srouter::handlers
 
     void TunEndpoint::send_packet_to_net_if(IPPacket pkt)
     {
-        _router.loop.call([this, pkt = std::move(pkt)]() mutable { _net_if->write_packet(std::move(pkt)); });
+        _router._jq->call([this, pkt = std::move(pkt)]() mutable { _net_if->write_packet(std::move(pkt)); });
     }
 
     void TunEndpoint::rewrite_and_send_packet(IPPacket&& pkt, const ipv4& src, const ipv4& dest)
@@ -496,7 +496,7 @@ namespace srouter::handlers
 
     void TunEndpoint::start_poller()
     {
-        _poller = std::make_unique<ev::FDPoller>(_router.loop, _net_if->PollFD(), [this] {
+        _poller = std::make_unique<ev::FDPoller>(_router.loop(), _net_if->PollFD(), [this] {
             for (auto pkt = _net_if->read_next_packet(); not pkt.empty(); pkt = _net_if->read_next_packet())
             {
                 log::trace(logcat, "packet router receiving {}", pkt.info_line());

--- a/src/link/endpoint.cpp
+++ b/src/link/endpoint.cpp
@@ -91,7 +91,7 @@ namespace srouter::link
             [this](quic::Connection& conn, uint64_t ec) { on_conn_closed(conn, ec); },
             [this](quic::datagram dgram) {
                 // Transfer handling to the router loop:
-                router.loop.call([this, msg = std::move(dgram).extract()]() mutable {
+                router._jq->call([this, msg = std::move(dgram).extract()]() mutable {
                     manager.handle_session_message(std::move(msg));
                 });
             },
@@ -190,14 +190,14 @@ namespace srouter::link
     {
         if (router.is_service_node)
         {
-            redundancy_ticker = router.loop.call_every(REDUNDANT_LINGER, [this] { close_redundant(); });
-            dereg_conn_ticker = router.loop.call_every(1min, [this] { check_deregged_conns(); });
+            redundancy_ticker = router.loop().call_every(REDUNDANT_LINGER, [this] { close_redundant(); });
+            dereg_conn_ticker = router.loop().call_every(1min, [this] { check_deregged_conns(); });
         }
     }
 
     link::Connection* Endpoint::get_relay_conn(const RouterID& relay) const
     {
-        return router.loop.call_get([this, relay]() -> link::Connection* {
+        return router._jq->call_get([this, relay]() -> link::Connection* {
             if (router.is_service_node)
             {
                 if (auto it = relay_conns.find(relay); it != relay_conns.end())
@@ -289,7 +289,7 @@ namespace srouter::link
     {
         if (router.is_service_node)
             return nullptr;
-        return router.loop.call_get([this, remote]() -> link::Connection* {
+        return router._jq->call_get([this, remote]() -> link::Connection* {
             if (auto itr = client_conns.find(remote); itr != client_conns.end())
                 return itr->second.get();
             return nullptr;
@@ -298,7 +298,7 @@ namespace srouter::link
 
     void Endpoint::for_each_relay_conn(std::function<void(const RouterID&, link::Connection&)> func) const
     {
-        assert(router.loop.inside());
+        assert(router.loop().inside());
 
         if (manager.is_stopping)
             return;
@@ -405,7 +405,7 @@ namespace srouter::link
     {
         if (not router.is_service_node)
             return {0};
-        return router.loop.call_get([this] {
+        return router._jq->call_get([this] {
             std::array<int, 5> result{0};
             auto& [relays, out, in, pending, clients] = result;
 
@@ -426,14 +426,14 @@ namespace srouter::link
 
     std::array<int, 2> Endpoint::client_connection_counts() const
     {
-        return router.loop.call_get([this] {
+        return router._jq->call_get([this] {
             return std::array{static_cast<int>(client_conns.size()), static_cast<int>(pending_outbound.size())};
         });
     }
 
     int Endpoint::num_relay_conns(bool include_pending) const
     {
-        return router.loop.call_get([this, &include_pending] {
+        return router._jq->call_get([this, &include_pending] {
             int c;
             if (router.is_service_node)
             {
@@ -459,7 +459,7 @@ namespace srouter::link
 
     std::pair<bool, quic::BTRequestStream*> Endpoint::ctrl_stream_impl(const RelayContact& rc)
     {
-        assert(router.loop.inside());
+        assert(router.loop().inside());
         std::pair<bool, quic::BTRequestStream*> result;
         auto& [res_est, res_str] = result;
 
@@ -515,7 +515,7 @@ namespace srouter::link
 
         if (response_handler)
             // Wrap the handler to transfer to the router loop for execution:
-            response_handler = [f = std::move(response_handler), &rloop = router.loop](quic::message m) mutable {
+            response_handler = [f = std::move(response_handler), &rloop = router.loop()](quic::message m) mutable {
                 rloop.call([f = std::move(f), m = std::move(m)]() mutable { f(std::move(m)); });
             };
 
@@ -571,7 +571,7 @@ namespace srouter::link
 
         if (response_handler)
             // Wrap the handler to transfer to the router loop for execution:
-            response_handler = [f = std::move(response_handler), &rloop = router.loop](quic::message m) mutable {
+            response_handler = [f = std::move(response_handler), &rloop = router.loop()](quic::message m) mutable {
                 rloop.call([f = std::move(f), m = std::move(m)]() mutable { f(std::move(m)); });
             };
 
@@ -783,7 +783,7 @@ namespace srouter::link
             inbound_cstream = make_control(conn, as_bspan(conn.remote_key()), conn.selected_alpn());
         }
 
-        router.loop.call([this, weak = conn.weak_from_this(), inbound_cstream = std::move(inbound_cstream)]() mutable {
+        router._jq->call([this, weak = conn.weak_from_this(), inbound_cstream = std::move(inbound_cstream)]() mutable {
             auto conn = weak.lock();
             if (not conn)
             {
@@ -828,7 +828,7 @@ namespace srouter::link
         // attempt beyond the end of `this.loop`.  Thus we capture everything we need into the
         // lambda here, while we are still in the network loop.
 
-        router.loop.call([this,
+        router._jq->call([this,
                           alive = canary,
                           conn_refid = conn.reference_id(),
                           alpn,

--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -71,11 +71,11 @@ namespace srouter::link
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
         s.register_handler("path_control"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable { handle_path_control(std::move(msg)); });
+            router._jq->call([this, msg = std::move(m)]() mutable { handle_path_control(std::move(msg)); });
         });
 
         s.register_handler("session_control"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable { handle_path_session_control(std::move(msg)); });
+            router._jq->call([this, msg = std::move(m)]() mutable { handle_path_session_control(std::move(msg)); });
         });
 
         if (not router.is_service_node)
@@ -85,28 +85,28 @@ namespace srouter::link
         }
 
         s.register_handler("path_build"s, [this, remote](quic::message m) {
-            router.loop.call(
+            router._jq->call(
                 [this, remote, msg = std::move(m)]() mutable { handle_path_build(std::move(msg), remote); });
         });
 
         s.register_handler("fetch_rcs"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable {
+            router._jq->call([this, msg = std::move(m)]() mutable {
                 handle_direct_request(&Manager::handle_fetch_rcs, std::move(msg));
             });
         });
 
         s.register_handler("gossip_rc"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable { handle_gossip_rc(std::move(msg)); });
+            router._jq->call([this, msg = std::move(m)]() mutable { handle_gossip_rc(std::move(msg)); });
         });
 
         s.register_handler("publish_cc"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable {
+            router._jq->call([this, msg = std::move(m)]() mutable {
                 handle_direct_request(&Manager::handle_publish_cc, std::move(msg));
             });
         });
 
         s.register_handler("find_cc"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable {
+            router._jq->call([this, msg = std::move(m)]() mutable {
                 handle_direct_request(&Manager::handle_find_cc, std::move(msg));
             });
         });
@@ -115,7 +115,7 @@ namespace srouter::link
         // replies with "pong" (we don't actually need a loop transfer here for the reply, but do it anyway so
         // that ping requests check that our router loop isn't stuck).
         s.register_handler("ping"s, [this](quic::message m) {
-            router.loop.call([this, m = std::move(m)] {
+            router._jq->call([this, m = std::move(m)] {
                 m.respond("pong");
                 router.on_test_ping();
             });
@@ -125,7 +125,7 @@ namespace srouter::link
     void Manager::register_bootstrap_commands(quic::BTRequestStream& s)
     {
         s.register_handler("bfetch_rcs"s, [this](quic::message m) {
-            router.loop.call([this, msg = std::move(m)]() mutable { handle_fetch_bootstrap_rcs(std::move(msg)); });
+            router._jq->call([this, msg = std::move(m)]() mutable { handle_fetch_bootstrap_rcs(std::move(msg)); });
         });
 
         log::trace(logcat, "Registered bootstrap commands for inbound bootstrap connection");
@@ -138,7 +138,7 @@ namespace srouter::link
         if (is_stopping.exchange(true))
             return;
 
-        router.loop.call_get([this] { endpoint.shutdown(); });
+        router._jq->call_get([this] { endpoint.shutdown(); });
     }
 
     Manager::~Manager() { stop(); }

--- a/src/linux/sd_service_manager.cpp
+++ b/src/linux/sd_service_manager.cpp
@@ -35,13 +35,10 @@ namespace srouter::sys
             }
         }
 
-        void report_periodic_stats() override
+        void report_periodic_stats(const std::string& stats) override
         {
-            if (m_Context and m_Context->router and not m_disable)
-            {
-                auto status = fmt::format("WATCHDOG=1\nSTATUS={}", m_Context->router->status_line());
-                ::sd_notify(0, status.c_str());
-            }
+            auto status = fmt::format("WATCHDOG=1\nSTATUS={}", stats);
+            ::sd_notify(0, status.c_str());
         }
 
         void system_changed_our_state(ServiceState) override

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -141,7 +141,7 @@ namespace srouter
     std::vector<const RelayContact*> NodeDB::get_n_random_rcs(
         int n, bool shuffle, const std::function<bool(const RelayContact&)>& predicate) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
 #ifdef SROUTER_DEBUG_PATH_SEED
         if (auto& s = _router.config().paths.debug_path_seed)
         {
@@ -170,7 +170,7 @@ namespace srouter
     std::vector<const RelayContact*> NodeDB::get_n_random_edge_rcs(
         int n, bool shuffle, const std::function<bool(const RelayContact&)>& predicate) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         auto& strict = _router.config().paths.strict_edges;
         if (_router.is_service_node || strict.empty())
             return get_n_random_rcs(n, shuffle, predicate);
@@ -200,7 +200,7 @@ namespace srouter
 
     void NodeDB::bootstrap()
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         assert(!_bootstraps.empty());
         _bootstrap_running = true;
 
@@ -241,7 +241,7 @@ namespace srouter
                     rc.addr());
                 auto [conn, control] = nodedb._router.link_endpoint().bootstrap_connect(rc);
                 control->command("bfetch_rcs", body, [this, conn](quic::message m) {
-                    nodedb._router.loop.call_soon([this, m = std::move(m)] {
+                    nodedb._router._jq->call_soon([this, m = std::move(m)] {
                         if (not m)
                             log::warning(logcat, "Bootstrap fetch failed: {}", m.timed_out ? "timeout" : m.body());
 
@@ -269,7 +269,7 @@ namespace srouter
 
     void NodeDB::purge_rcs(sys_ms now)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
         if (_router.is_stopping() || not _router.is_running())
@@ -338,7 +338,7 @@ namespace srouter
 
     void NodeDB::fetch_rcs()
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
 
         path::Path* selected_path = _router.session_endpoint().get_random_active_path();
         if (!selected_path)
@@ -406,7 +406,7 @@ namespace srouter
 
     void NodeDB::fetch_rids()
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         if (_router.is_stopping() || not _router.is_running())
         {
             log::debug(logcat, "NodeDB skipping RouterID fetch -- router is stopped!");
@@ -435,7 +435,7 @@ namespace srouter
         if (selected_paths.size() < 2)
         {
             log::debug(logcat, "Have fewer than 2 paths, not fetching RouterIDs yet.");
-            _router.loop.call_later(100ms, [this] { fetch_rids(); });
+            _router._jq->call_later(100ms, [this] { fetch_rids(); });
             return;
         }
         else if (selected_paths.size() < RID_SOURCE_COUNT)
@@ -482,7 +482,7 @@ namespace srouter
                 if (*result_count == results->size())
                 {
                     // FIXME: call again sooner if enough failed
-                    _router.loop.call_later(FETCH_INTERVAL, [this] { fetch_rids(); });
+                    _router._jq->call_later(FETCH_INTERVAL, [this] { fetch_rids(); });
                     handle_fetched_router_ids(*results);
                 }
             };
@@ -492,7 +492,7 @@ namespace srouter
 
     void NodeDB::handle_fetched_router_ids(const std::unordered_map<RouterID, std::unordered_set<RouterID>>& results)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         std::unordered_set<RouterID> accepted{};
 
         auto itr = results.begin();
@@ -528,7 +528,7 @@ namespace srouter
     {
         log::trace(logcat, "NodeDB starting tickers...");
 
-        _purge_ticker = _router.loop.call_every(PURGE_INTERVAL, [this] { purge_rcs(); });
+        _purge_ticker = _router.loop().call_every(PURGE_INTERVAL, [this] { purge_rcs(); });
 
         auto need_bootstrap = num_rcs() < MIN_ACTIVE_RCS;
         if (not has_bootstraps())
@@ -539,7 +539,7 @@ namespace srouter
 
         if (not _router.is_service_node)
         {
-            _router.loop.call_later(100ms, [this] { fetch_rids(); });
+            _router._jq->call_later(100ms, [this] { fetch_rids(); });
         }
 
         _0rtt_saver = _router.disk_loop.make_wakeable([this] { _0rtt_save(); });
@@ -572,7 +572,7 @@ namespace srouter
             num_rcs(),
             success ? "successful" : "failed",
             cooldown);
-        _router.loop.call_later(cooldown, [this] { bootstrap(); });
+        _router._jq->call_later(cooldown, [this] { bootstrap(); });
     }
 
     NodeDB::NodeDB(Router& r) : _router{r}, _root{_router.config().router.data_dir / nodedb_dirname}
@@ -705,7 +705,7 @@ namespace srouter
 
     void NodeDB::post_rid_fetch(bool shutdown)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
         fetch_counter = 0;
@@ -724,7 +724,7 @@ namespace srouter
 
     bool NodeDB::handle_bootstrap_result(const RouterID& source, std::string_view body)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         log::debug(logcat, "Received response to BootstrapRC fetch request...");
 
         int num = 0, n_new = 0;
@@ -999,14 +999,14 @@ namespace srouter
 
     const RelayContact* NodeDB::get_rc(const RouterID& pk) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         auto it = known_rcs.find(pk);
         return it != known_rcs.end() ? &it->second : nullptr;
     }
 
     bool NodeDB::put_rc(RelayContact rc)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
 
         const auto& rid = rc.router_id();
 
@@ -1052,7 +1052,7 @@ namespace srouter
 
     bool NodeDB::verify_store_gossip_rc(RelayContact rc)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         if (not is_registered(rc.router_id()) || rc.router_id() == _router.id())
             return false;
         return put_rc(std::move(rc));
@@ -1060,7 +1060,7 @@ namespace srouter
 
     int NodeDB::num_rcs(bool include_self) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         int total = static_cast<int>(known_rcs.size());
         if (not include_self and _router.is_service_node and known_rcs.contains(_router.id()))
             --total;
@@ -1069,7 +1069,7 @@ namespace srouter
 
     int NodeDB::num_rids() const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         if (_router.is_service_node)
         {
             std::shared_lock lock{_registered_relays_mutex};
@@ -1080,7 +1080,7 @@ namespace srouter
 
     void NodeDB::remove_rcs_if(const std::function<bool(const RelayContact&)>& remove)
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
 
         std::vector<RouterID> removed;
 
@@ -1103,7 +1103,7 @@ namespace srouter
 
     void NodeDB::remove_many_from_disk_async(const std::vector<RouterID>& remove) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         if (_root.empty())
             return;
 
@@ -1149,7 +1149,7 @@ namespace srouter
 
     std::vector<RouterID> NodeDB::find_many_closest_to(const PubKey& blinded_pk, int num_routers) const
     {
-        assert(_router.loop.inside());
+        assert(_router.loop().inside());
         if (num_routers <= 0)
             return {};
 

--- a/src/path/path_context.cpp
+++ b/src/path/path_context.cpp
@@ -17,7 +17,7 @@ namespace srouter::path
 
     void PathContext::expire_hops(sys_ms now)
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         int n = 0;
         for (auto it = _transit_hops.begin(); it != _transit_hops.end();)
         {
@@ -37,7 +37,7 @@ namespace srouter::path
 
     void PathContext::drop(const Path& path)
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         auto it = _path_map.find(path.edge().rxid);
         if (it != _path_map.end())
         {
@@ -49,7 +49,7 @@ namespace srouter::path
 
     void PathContext::drop(const TransitHop& thop)
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         for (const HopID* h : {&thop.txid, &thop.rxid})
         {
             auto it = _transit_hops.find(*h);
@@ -64,25 +64,25 @@ namespace srouter::path
 
     std::tuple<size_t, size_t> PathContext::path_ctx_stats() const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         return {_path_map.size() / 2, _transit_hops.size() / 2};
     }
 
     bool PathContext::has_transit_hop(const TransitHop& hop) const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         return has_transit_hop(hop.rxid) or has_transit_hop(hop.txid);
     }
 
     bool PathContext::has_transit_hop(const HopID& hop_id) const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         return _transit_hops.count(hop_id);
     }
 
     void PathContext::put_transit_hop(std::shared_ptr<TransitHop> hop)
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         _transit_hops.emplace(hop->rxid, hop);
         _transit_hops.emplace(hop->txid, std::move(hop));
     }
@@ -92,7 +92,7 @@ namespace srouter::path
 
     TransitHop* PathContext::get_transit_hop(const HopID& path_id) const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         if (auto itr = _transit_hops.find(path_id); itr != _transit_hops.end())
             return itr->second.get();
 
@@ -100,7 +100,7 @@ namespace srouter::path
     }
     std::shared_ptr<TransitHop> PathContext::get_transit_hop_ptr(const HopID& path_id) const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         if (auto itr = _transit_hops.find(path_id); itr != _transit_hops.end())
             return itr->second;
 
@@ -109,7 +109,7 @@ namespace srouter::path
 
     Path* PathContext::get_path(const HopID& hop_id) const
     {
-        assert(_r.loop.inside());
+        assert(_r.loop().inside());
         if (auto itr = _path_map.find(hop_id); itr != _path_map.end())
             return itr->second.get();
 

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -51,6 +51,7 @@ namespace srouter
         Config conf, std::shared_ptr<quic::Loop> loop, std::shared_ptr<vpn::Platform> vpnPlatform, std::promise<void> p)
         : _config{std::move(conf)},
           _loop{std::move(loop)},
+          _jq{std::make_unique<quic::JobQueue>(*_loop)},
           _vpn{std::move(vpnPlatform)},
           _close_promise{std::move(p)},
           _contact_db{std::make_unique<ContactDB>(*this)},
@@ -70,7 +71,7 @@ namespace srouter
 
         init_logging();
 
-        _loop->call_get([this] {
+        _jq->call_get([this] {
             log::debug(logcat, "Inside router loop, initializing router");
             configure();
             start();
@@ -111,10 +112,10 @@ namespace srouter
                 delay += RelayContact::MIN_GOSSIP_RC_AGE;
             }
             log::debug(logcat, "Delaying initial RC broadcast for {}", delay);
-            loop.call_later(delay, [this] {
+            _jq->call_later(delay, [this] {
                 regenerate_rc();
                 log::debug(logcat, "Starting RC regen ticker");
-                _gossip_ticker = loop.call_every(RC_UPDATE_INTERVAL, [this] { regenerate_rc(); });
+                _gossip_ticker = _loop->call_every(RC_UPDATE_INTERVAL, [this] { regenerate_rc(); });
             });
 
             if (not _config.oxend.disable_testing)
@@ -578,7 +579,7 @@ namespace srouter
                             if (!_dns)
                                 _dns = _loop->make_shared<dns::Listener>(*this, addr);
                             else
-                                _dns->listen(loop, addr);
+                                _dns->listen(loop(), addr);
 
                             log::info(log_global, "DNS listening on {} port {}", addr.host(), _dns->last_port);
                         }
@@ -885,18 +886,18 @@ namespace srouter
 
     bool Router::is_edge_connected() const
     {
-        return loop.call_get([this] { return _is_edge_connected; });
+        return _jq->call_get([this] { return _is_edge_connected; });
     }
     bool Router::is_path_connected() const
     {
-        return loop.call_get([this] { return _is_edge_connected && _has_established_paths; });
+        return _jq->call_get([this] { return _is_edge_connected && _has_established_paths; });
     }
 
     void Router::on_connected(std::function<void()> callback, bool with_paths, bool persistent)
     {
         if (!callback)
             return;
-        loop.call([this, with_paths, callback = std::move(callback), persistent] {
+        _jq->call([this, with_paths, callback = std::move(callback), persistent] {
             bool fire_now = _is_edge_connected && (_has_established_paths || !with_paths);
             if (fire_now)
                 try_calling(logcat, callback);
@@ -910,7 +911,7 @@ namespace srouter
     {
         if (!callback)
             return;
-        loop.call([this, callback = std::move(callback), persistent, with_paths] {
+        _jq->call([this, callback = std::move(callback), persistent, with_paths] {
             bool fire_now = !_is_edge_connected || (with_paths && !_has_established_paths);
             if (fire_now)
                 try_calling(logcat, callback);
@@ -935,7 +936,7 @@ namespace srouter
 
     void Router::on_edge_conn_change()
     {
-        assert(loop.inside());
+        assert(_loop->inside());
 
         int conns = link_endpoint().num_relay_conns();
         if (conns == 0 and _is_edge_connected)
@@ -1023,7 +1024,7 @@ namespace srouter
         if (_is_stopping.exchange(true))
             return;  // Lost a race with something else trying to stop
 
-        _loop->call([this] {
+        _jq->call([this] {
 #ifndef SROUTER_EMBEDDED_ONLY
             if (!embedded())
             {

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -89,8 +89,9 @@ namespace srouter
             _tun->start_poller();
 
         if (!embedded())
-            _service_stat_ticker = _loop->call_every(
-                SERVICE_MANAGER_REPORT_INTERVAL, []() { sys::service_manager->report_periodic_stats(); });
+            _service_stat_ticker = _loop->call_every(SERVICE_MANAGER_REPORT_INTERVAL, [this]() {
+                sys::service_manager->report_periodic_stats(status_line());
+            });
 #endif
 
         _node_db->start();

--- a/src/router/router.hpp
+++ b/src/router/router.hpp
@@ -109,8 +109,16 @@ namespace srouter
         void start();
 
         Config _config;
+
+      public:
         const std::shared_ptr<quic::Loop> _loop;
 
+        // unique_ptr instead of concrete instance so methods which are const apart from using
+        // this object can still be const.
+        // FIXME: make sure this is okay?
+        const std::unique_ptr<quic::JobQueue> _jq;
+
+      private:
         // path to write our self signed rc to
         std::filesystem::path our_rc_file;
 
@@ -287,7 +295,7 @@ namespace srouter
 
         Profiling& router_profiling() { return _router_profiling; }
 
-        quic::Loop& loop{*_loop};
+        quic::Loop& loop() { return *_loop; }
 
         // If this router is not a registered service node, does nothing.  Otherwise this regenerate
         // the RC for this router, add it to the nodedb, saves it to disk, and gossips it.

--- a/src/rpc/oxend_rpc.cpp
+++ b/src/rpc/oxend_rpc.cpp
@@ -38,7 +38,7 @@ namespace srouter::rpc
             [](oxenmq::ConnectionID) {},
             [this, url](oxenmq::ConnectionID, std::string_view f) {
                 log::info(logcat, "Failed to connect to oxend at {}", f);
-                _router.loop.call([this, url]() { connect_async(url); });
+                _router._jq->call([this, url]() { connect_async(url); });
             });
     }
 
@@ -180,7 +180,7 @@ namespace srouter::rpc
 
         log::info(logcat, "Starting OxendRPC ping ticker...");
         ping();
-        _ping_ticker = _router.loop.call_every(PING_INTERVAL, [this] { ping(); });
+        _ping_ticker = _router.loop().call_every(PING_INTERVAL, [this] { ping(); });
     }
 
     void OxendRPC::handle_new_service_node_list(const nlohmann::json& j)
@@ -235,7 +235,7 @@ namespace srouter::rpc
 
     void OxendRPC::inform_connection(RouterID router, bool success)
     {
-        _router.loop.call([router, success, this]() {
+        _router._jq->call([router, success, this]() {
             const nlohmann::json req = {{"passed", success}, {"pubkey", router.ToHex()}, {"type", "srouter"}};
             request(
                 "admin.report_peer_status",
@@ -315,7 +315,7 @@ namespace srouter::rpc
                         result.reset();
                     }
                 }
-                _router.loop.call(
+                _router._jq->call(
                     [resultHandler, result = std::move(result)]() mutable { resultHandler(std::move(result)); });
             },
             std::move(req).str());

--- a/src/rpc/rpc_request.hpp
+++ b/src/rpc/rpc_request.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "config/config.hpp"
-#include "json_bt.hpp"
 #include "router/router.hpp"
 #include "rpc_request_decorators.hpp"
-#include "rpc_request_definitions.hpp"
 #include "rpc_request_parser.hpp"
 #include "rpc_server.hpp"
 
@@ -59,7 +56,7 @@ namespace srouter::rpc
 
             if (not std::is_base_of_v<Immediate, RPC>)
             {
-                server._router.loop.call_soon(std::move(handler));
+                server._router._jq->call_soon(std::move(handler));
             }
             else
             {

--- a/src/rpc/rpc_server.cpp
+++ b/src/rpc/rpc_server.cpp
@@ -1,13 +1,11 @@
 #include "rpc_server.hpp"
 
 #include "config/config.hpp"
-#include "config/ini.hpp"
 #include "constants/version.hpp"
 #include "contact/client_contact.hpp"
 #include "router/router.hpp"
 #include "rpc/rpc_request_definitions.hpp"
 #include "rpc_request.hpp"
-#include "util/logging/buffer.hpp"
 
 #include <nlohmann/json.hpp>
 #include <oxenc/base32z.h>
@@ -125,7 +123,7 @@ namespace srouter::rpc
             return;
         }
 
-        _router.loop.call_soon([&]() { _router.stop(); });
+        _router._jq->call_soon([&]() { _router.stop(); });
 
         SetJSONResponse("OK", halt.response);
     }
@@ -324,7 +322,7 @@ namespace srouter::rpc
             return;
         }
 
-        _router.loop.call([this, netaddr = *maybe_netaddr, replier = findcc.move()]() mutable {
+        _router._jq->call([this, netaddr = *maybe_netaddr, replier = findcc.move()]() mutable {
             _router.session_endpoint().lookup_client_intro(
                 netaddr.pubkey, [&replier](std::optional<srouter::ClientContact> cc) {
                     nlohmann::json result;
@@ -368,7 +366,7 @@ namespace srouter::rpc
             return;
         }
 
-        _router.loop.call([this, netaddr = *maybe_netaddr]() {
+        _router._jq->call([this, netaddr = *maybe_netaddr]() {
             try
             {
                 log::debug(logcat, "Beginning session init to remote instance: {}", netaddr);
@@ -412,7 +410,7 @@ namespace srouter::rpc
 
         auto& netaddr = *maybe_netaddr;
 
-        _router.loop.call([&]() {
+        _router._jq->call([&]() {
             try
             {
                 if (auto session = _router.session_endpoint().get_session(netaddr))

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -172,7 +172,8 @@ namespace srouter::session
 
             quic_ep = quic::Endpoint::endpoint(
                 // TODO FIXME: this should probably attach to the network loop rather than the logic loop:
-                session._r.loop,
+                // TODO FIXME: this is now further weird with the separate JobQueue change to libquic
+                session._r.loop(),
                 FAKE_QUIC_ADDR,
                 std::move(quic_send),
                 std::move(new_conn),
@@ -226,7 +227,8 @@ namespace srouter::session
 
             auto _handle = TCPHandle::make_server(
                 // TODO FIXME: this should probably attach to the network loop rather than the logic loop:
-                session._r.loop,
+                // TODO FIXME: this is now further weird with the separate JobQueue change to libquic
+                session._r.loop(),
                 [this, dest_port](struct bufferevent* _bev, evutil_socket_t _fd) -> TCPConnection* {
                     auto s =
                         quic_conn->open_stream<quic::Stream>([_bev](quic::Stream& s, std::span<const std::byte> data) {
@@ -1752,7 +1754,7 @@ namespace srouter::session
     void OutboundSession::on_path_build_success(int64_t /*build_id*/, path::Path& p)
     {
         log::debug(logcat, "{} path {} built successfully", _remote, p);
-        assert(router.loop.inside());
+        assert(router.loop().inside());
 
         // If we don't have a current path then immediately switch to this built in.
         //

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -25,22 +25,17 @@ namespace session::router
 {
     namespace log = oxen::log;
 
-    static auto make_embedded_context() { return std::make_unique<srouter::Context>(/*embedded=*/true); }
-
     SessionRouter::SessionRouter(std::string config, std::shared_ptr<oxen::quic::Loop> loop)
-        : context{make_embedded_context()}
-    {
-        context->start(srouter::Config{srouter::config::Type::EmbeddedClient, std::move(config)}, loop);
-    }
+        : context{std::make_unique<srouter::Context>(
+              /*embedded=*/true, srouter::Config{srouter::config::Type::EmbeddedClient, std::move(config)}, loop)}
+    {}
 
     SessionRouter::SessionRouter(path_ctor, const std::filesystem::path& config, std::shared_ptr<oxen::quic::Loop> loop)
-        : context{make_embedded_context()}
-    {
-        ;
-        context->start(srouter::Config{srouter::config::Type::EmbeddedClient, config}, loop);
-    }
+        : context{std::make_unique<srouter::Context>(
+              /*embedded=*/true, srouter::Config{srouter::config::Type::EmbeddedClient, config}, loop)}
+    {}
 
-    SessionRouter::SessionRouter(Network n, std::shared_ptr<oxen::quic::Loop> loop) : context{make_embedded_context()}
+    SessionRouter::SessionRouter(Network n, std::shared_ptr<oxen::quic::Loop> loop)
     {
         srouter::Config conf{srouter::config::Type::EmbeddedClient};
         switch (n)
@@ -54,14 +49,10 @@ namespace session::router
             default:
                 throw std::invalid_argument{"Unknown/unsupported network value passed to Session Router constructor"};
         }
-        context->start(std::move(conf), loop);
+        context = std::make_unique<srouter::Context>(/*embedded-*/ true, std::move(conf), loop);
     }
 
-    SessionRouter::~SessionRouter()
-    {
-        context->stop();
-        context->wait();
-    }
+    SessionRouter::~SessionRouter() {}
 
     void SessionRouter::on_connected(std::function<void()> callback, bool with_path, bool persist)
     {

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -184,7 +184,7 @@ namespace session::router
             return;
         }
 
-        context->router->loop.call([address = std::move(address),
+        context->router->_jq->call([address = std::move(address),
                                     callback = std::move(callback),
                                     &ep = context->router->session_endpoint()]() mutable {
             ep.resolve_sns(
@@ -212,7 +212,7 @@ namespace session::router
             return std::nullopt;
         }
 
-        return context->router->loop.call_get([&r = context->router, addr = std::move(netaddr)]() {
+        return context->router->_jq->call_get([&r = context->router, addr = std::move(netaddr)]() {
             std::optional<snode_path> ret;
             if (auto* s = r->session_endpoint().get_session(addr))
                 ret = to_snode_path(s->current_path_info());
@@ -222,7 +222,7 @@ namespace session::router
 
     std::vector<session_path> SessionRouter::get_all_session_paths()
     {
-        return context->router->loop.call_get([&r = context->router]() {
+        return context->router->_jq->call_get([&r = context->router]() {
             std::vector<session_path> ret;
             r->session_endpoint().for_each_session(
                 [&ret](const srouter::NetworkAddress& addr, const srouter::session::Session& s) {

--- a/src/util/service_manager.hpp
+++ b/src/util/service_manager.hpp
@@ -46,7 +46,7 @@ namespace srouter::sys
         virtual void report_changed_state() = 0;
 
         /// report our stats on each timer tick
-        virtual void report_periodic_stats() {};
+        virtual void report_periodic_stats([[maybe_unused]] const std::string& stats) {};
 
         void starting()
         {

--- a/src/util/service_manager.hpp
+++ b/src/util/service_manager.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace srouter
 {
     struct Context;


### PR DESCRIPTION
JobQueue was added to libquic so that an object could have all of its children which will queue jobs use that queue rather than the Loop's global queue.  This is so no jobs referencing Router or its children will outlive Router, as this will crash.

Depends libquic 1.8.0 (merge pending)