### PR TITLE
fix: use htons() instead of htonl() for sin_port, fix cmake typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ if(SROUTER_DAEMON AND NOT SROUTER_FULL)
   message(FATAL_ERROR "Cannot use SROUTER_DAEMON without SROUTER_FULL platform support!")
 endif()
 
-option(SROUTER_GRAPH_DEPENDENCIES "Produce graphviz representation of cmake dependencies" OFF)
 
 option(SROUTER_VERSION_SO "Add the project version to the shared library filename, e.g. libsession-router1.2.3.so instead of libsession-router.so" OFF)
 
@@ -79,8 +78,8 @@ set(SROUTER_BOOTSTRAP_FALLBACK_TESTNET "${PROJECT_SOURCE_DIR}/contrib/bootstrap/
 
 include(cmake/enable_lto.cmake)
 
-option(CROSS_PLATFORM "cross compiler platform" "Linux")
-option(CROSS_PREFIX "toolchain cross compiler prefix" "")
+set(CROSS_PLATFORM "Linux" CACHE STRING "cross compiler platform")
+set(CROSS_PREFIX "" CACHE STRING "toolchain cross compiler prefix")
 
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 option(STATIC_LINK "link statically against dependencies" ${BUILD_STATIC_DEPS})
@@ -95,12 +94,6 @@ endif()
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
-
-# set(debug OFF)
-# if(CMAKE_BUILD_TYPE MATCHES "[Dd][Ee][Bb][Uu][Gg]")
-#   set(debug ON)
-#   add_definitions(-DSROUTER_DEBUG)
-# endif()
 
 option(SROUTER_WARN_DEPRECATED "show deprecation warnings" OFF)
 
@@ -218,7 +211,7 @@ unset(GIT_VERSION_REAL)
 if(NOT GIT_VERSION)
   execute_process(
       COMMAND git rev-parse --short HEAD
-      WOKRING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       OUTPUT_VARIABLE GIT_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE
   )

--- a/src/ev/tcp.cpp
+++ b/src/ev/tcp.cpp
@@ -146,7 +146,7 @@ namespace srouter
             size_t written = 0;
             while (written < pending_buffer.size())
             {
-                constexpr size_t chunk_size = 1500;  // FIXME: this, obviously; ass number
+                constexpr size_t chunk_size = 1500;  // FIXME: this, obviously; arbitrary number
                 size_t s = std::min(chunk_size, pending_buffer.size() - written);
                 if (bufferevent_write(_bev, cur, s) != 0)
                 {
@@ -228,7 +228,7 @@ namespace srouter
         event_base *_ev, quic::Address src, std::shared_ptr<quic::Stream> s, uint16_t port)
     {
         sockaddr_in _addr = src.in4();
-        _addr.sin_port = htonl(port);
+        _addr.sin_port = htons(port);
 
         // NB: BEV_OPT_THREADSAFE not used because this should only ever be touched
         // by a single thread.
@@ -255,7 +255,7 @@ namespace srouter
         sockaddr_in _tcp{};
         _tcp.sin_family = AF_INET;
         _tcp.sin_addr.s_addr = INADDR_ANY;
-        _tcp.sin_port = htonl(port);
+        _tcp.sin_port = htons(port);
 
         _tcp_listener = _ev.template shared_ptr<struct evconnlistener>(
             evconnlistener_new_bind(


### PR DESCRIPTION
## Summary

Two bug fixes + cmake cleanup:

**1. `src/ev/tcp.cpp:231,258` — `htonl()` → `htons()`**

`sin_port` is a 16-bit field requiring `htons()` (host-to-network short). `htonl()` (32-bit) produces incorrect byte ordering.

**2. `CMakeLists.txt:221` — `WOKRING_DIRECTORY` → `WORKING_DIRECTORY`**

Typo causes `execute_process` to ignore the directory argument.

**Also:**
- Removed unused `SROUTER_GRAPH_DEPENDENCIES` option (defined but never referenced)
- Fixed `option()` misuse for `CROSS_PLATFORM`/`CROSS_PREFIX` (should be `set(CACHE STRING)`)
- Removed commented-out debug block