### PR TITLE
docs: fix stale build deps, C++ version, and org URLs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -60,14 +60,11 @@ Build requirements:
 
 * Git
 * CMake
-* C++ 17 capable C++ compiler
-* libuv >= 1.27.0
+* C++ 20 capable C++ compiler (gcc 12+ or clang 15+)
 * libsodium >= 1.0.18
-* libssl (for session-router-bootstrap)
-* libcurl (for session-router-bootstrap)
+* libevent >= 2.1
+* libzstd >= 1.3
 * libunbound
-* libzmq
-* cppzmq
 
 ### Linux Compile
 

--- a/readme_es.md
+++ b/readme_es.md
@@ -8,14 +8,14 @@ Puede aprender a grandes razgos sobre el diseño de LLARP [aquí](docs/high-leve
 
 Y puede leer las especificaciones del protocolo [aquí](docs/proto_v0.txt) , documento técnico en idioma ingles.
 
-Puede ver la documentación, en ingles, de como empezar [aqui](https://oxen-io.github.io/loki-docs/SessionRouter/SessionRouterOverview/) .
+Puede ver la documentación, en ingles, de como empezar [aqui](https://session-foundation.github.io/loki-docs/SessionRouter/SessionRouterOverview/) .
 
-[![Build Status](https://ci.oxen.rocks/api/badges/oxen-io/session_router/status.svg?ref=refs/heads/dev)](https://ci.oxen.rocks/oxen-io/session_router)
+[![Build Status](https://ci.oxen.rocks/api/badges/session-foundation/session_router/status.svg?ref=refs/heads/dev)](https://ci.oxen.rocks/session-foundation/session_router)
 
 
 ## Uso
 
-Vea, en ingles, [documentación](https://oxen-io.github.io/loki-docs/SessionRouter/SessionRouterOverview/) en como comenzar.
+Vea, en ingles, [documentación](https://session-foundation.github.io/loki-docs/SessionRouter/SessionRouterOverview/) en como comenzar.
 
 También lea, en ingles, [La guia de pruebas publicas](https://lokidocs.com/SessionRouter/Guides/PublicTestingGuide/#1-session_router-installation) para la instalación y mas información util.
 
@@ -81,7 +81,7 @@ Requerimientos de compilación:
 compilando:
 
     $ sudo apt install build-essential cmake git libcap-dev curl libuv1-dev libsodium-dev pkg-config
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -104,7 +104,7 @@ esto coloca el paquete compilado en `../`
 compilando:
     este seguro que usted tiene cmake, libuv y las herramientas de terminal de xcode ya instaladas
 
-     $ git clone --recursive https://github.com/oxen-io/session_router
+     $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -120,7 +120,7 @@ instalando:
 compilar (donde `$ARCH` es su plataforma - `i686` or `x86_64`):
 
     $ pacman -Sy base-devel mingw-w64-$ARCH-toolchain git libtool autoconf mingw-w64-$ARCH-cmake
-    $ git clone https://github.com/oxen-io/session_router.git
+    $ git clone https://github.com/session-foundation/session_router.git
     $ cd session_router
     $ mkdir -p build; cd build
     $ cmake .. -DCMAKE_BUILD_TYPE=[Debug|Release] -DSTATIC_LINK_RUNTIME=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -G 'Unix Makefiles'
@@ -150,7 +150,7 @@ compilando:
     $ sudo pkg install build-essential gcc8 wget tuntap cmake (opcional: ninja ccache - de los extra de omnios) (OmniOS CE)
     $ sudo pkg install base-developer-utilities developer-gnu developer-studio-utilities gcc-7 wget cmake (Solaris de Oracle, ver notas)
     $ sudo pkg install build-essential wget gcc-8 documentation/tuntap header-tun tun (opcional: ninja ccache) (todos los demas SunOS)
-    $ git clone https://github.com/oxen-io/session_router
+    $ git clone https://github.com/session-foundation/session_router
     $ cd session_router
     $ gmake -j8
 
@@ -168,7 +168,7 @@ PENDIENTE: agregar instrucciones para pkgsrc
 compilando:
 
     # pkg_add curl cmake git (opcional: ninja ccache)
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -184,7 +184,7 @@ instalando (root):
 compilando:
 
     $ pkg install cmake git curl libuv-1.27.0 libsodium
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build

--- a/readme_fr.md
+++ b/readme_fr.md
@@ -6,7 +6,7 @@ SessionRouter est l'implementation de référence du LLARP (Low Latency Anonymou
 
 Vous pouvez en savoir plus sur le haut niveau de conception du LLARP [ici](docs/)
 
-[![Build Status](https://ci.oxen.rocks/api/badges/oxen-io/session_router/status.svg?ref=refs/heads/dev)](https://ci.oxen.rocks/oxen-io/session_router)
+[![Build Status](https://ci.oxen.rocks/api/badges/session-foundation/session_router/status.svg?ref=refs/heads/dev)](https://ci.oxen.rocks/session-foundation/session_router)
 
 ## Installer
 
@@ -59,7 +59,7 @@ Vous pouvez installer les paquets debian en utilisant :
 Si vous voulez construire session_router à partir des sources :
 
     $ sudo apt install build-essential cmake git libcap-dev pkg-config automake libtool libuv1-dev libsodium-dev libzmq3-dev libcurl4-openssl-dev libevent-dev nettle-dev libunbound-dev libsqlite3-dev libssl-dev nlohmann-json3-dev
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -69,7 +69,7 @@ Si vous voulez construire session_router à partir des sources :
 
 #### Arch Linux <span id="mom-cancel-my-meetings-arch-linux-broke-again" />
 
-En raison de [circonstances indépendantes de notre volonté](https://github.com/oxen-io/session_router/discussions/1823) un `PKGBUILD` fonctionnel peut être trouvé [ici](https://raw.githubusercontent.com/oxen-io/session_router/makepkg/contrib/archlinux/PKGBUILD).
+En raison de [circonstances indépendantes de notre volonté](https://github.com/session-foundation/session_router/discussions/1823) un `PKGBUILD` fonctionnel peut être trouvé [ici](https://raw.githubusercontent.com/session-foundation/session_router/makepkg/contrib/archlinux/PKGBUILD).
 
 #### Compilation croisée pour Linux <span id="linux-cross" />
 
@@ -98,10 +98,10 @@ La compilation du code source de SessionRouter par les utilisateurs finaux n'est
 
 ### Windows <span id="windows-install" />
 
-Vous pouvez obtenir la dernière version stable de Windows à l'adresse https://session_router.org/ ou consulter la [page des versions sur github] (https://github.com/oxen-io/session_router/releases).
+Vous pouvez obtenir la dernière version stable de Windows à l'adresse https://session_router.org/ ou consulter la [page des versions sur github] (https://github.com/session-foundation/session_router/releases).
 
 
-les compilation automatique de nuit pour les courageux ou les impatients peuvent être trouvées à partir de notre pipeline CI [ici](https://oxen.rocks/oxen-io/session_router/)
+les compilation automatique de nuit pour les courageux ou les impatients peuvent être trouvées à partir de notre pipeline CI [ici](https://oxen.rocks/session-foundation/session_router/)
 
 #### Construire les paquets sur Windows <span id="win32-cross" />
 
@@ -120,7 +120,7 @@ configuration:
 
 building:
 
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ ./contrib/windows.sh
 
@@ -131,7 +131,7 @@ Currently has no VPN Platform code, see #1513
 construction:
 
     $ pkg install cmake git pkgconf
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -146,10 +146,10 @@ installation (root):
 
 Nous avons un APK Android pour le VPN session_router via l'API VPN android. 
 
-A venir sur F-Droid quand cela arrivera. [[issue]](https://github.com/oxen-io/session_router-flutter-app/issues/8)
+A venir sur F-Droid quand cela arrivera. [[issue]](https://github.com/session-foundation/session_router-flutter-app/issues/8)
 
-* [code source](https://github.com/oxen-io/session_router-flutter-app)
-* [CI builds](https://oxen.rocks/oxen-io/session_router/)
+* [code source](https://github.com/session-foundation/session_router-flutter-app)
+* [CI builds](https://oxen.rocks/session-foundation/session_router/)
 
 ## Usage
 

--- a/readme_ru.md
+++ b/readme_ru.md
@@ -8,13 +8,13 @@ SessionRouter - реализация LLARP (протокол анонимной 
 
 Почитать спецификацию протокола LLARP [здесь](docs/proto_v0.txt)
 
-Почитать документацию о том, как начать работу [здесь](https://oxen-io.github.io/loki-docs/SessionRouter/SessionRouterOverview/)
+Почитать документацию о том, как начать работу [здесь](https://session-foundation.github.io/loki-docs/SessionRouter/SessionRouterOverview/)
 
-[![Build Status](https://drone.session_router.dev/api/badges/oxen-io/session_router/status.svg?ref=refs/heads/master)](https://drone.session_router.dev/oxen-io/session_router)
+[![Build Status](https://drone.session_router.dev/api/badges/session-foundation/session_router/status.svg?ref=refs/heads/master)](https://drone.session_router.dev/session-foundation/session_router)
 
 ## Использование
 
-О том как начать работу см. [Документацию](https://oxen-io.github.io/loki-docs/SessionRouter/SessionRouterOverview/)
+О том как начать работу см. [Документацию](https://session-foundation.github.io/loki-docs/SessionRouter/SessionRouterOverview/)
 
 Также прочтите [Public Testing Guide](https://lokidocs.com/SessionRouter/Guides/PublicTestingGuide/#1-session_router-installation) для установки и другой полезной информации.
 
@@ -72,7 +72,7 @@ SessionRouter - реализация LLARP (протокол анонимной 
 сборка:
 
     $ sudo apt install build-essential cmake git libcap-dev curl libuv1-dev libsodium-dev pkg-config
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -88,7 +88,7 @@ SessionRouter - реализация LLARP (протокол анонимной 
 сборка:
     убедитесь, что у вас установлены инструменты командной строки cmake, libuv и xcode
 
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -114,7 +114,7 @@ SessionRouter - реализация LLARP (протокол анонимной 
 
 сборка:
 
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build-windows
     $ cd build-windows
@@ -134,7 +134,7 @@ SessionRouter - реализация LLARP (протокол анонимной 
     $ sudo pkg install build-essential gcc8 wget tuntap cmake (optional: ninja ccache - from omnios extra) (OmniOS CE)
     $ sudo pkg install base-developer-utilities developer-gnu developer-studio-utilities gcc-7 wget cmake (Oracle Solaris, see note)
     $ sudo pkg install build-essential wget gcc-8 documentation/tuntap header-tun tun (optional: ninja ccache) (all other SunOS)
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cd build
@@ -150,7 +150,7 @@ SessionRouter - реализация LLARP (протокол анонимной 
 сборка:
 
     $ pkg install cmake git curl libuv libsodium pkgconf libunbound
-    $ git clone --recursive https://github.com/oxen-io/session_router
+    $ git clone --recursive https://github.com/session-foundation/session_router
     $ cd session_router
     $ mkdir build
     $ cmake -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
## Summary

- `docs/install.md`: C++17 → C++20 (project requires C++20)
- `docs/install.md`: removed stale dependencies (libuv, libzmq, cppzmq, libcurl, libssl) that are no longer used
- `readme_es.md`, `readme_fr.md`, `readme_ru.md`: updated oxen-io → session-foundation URLs to match current GitHub org