### PR TITLE
fix: typos — occured→occurred, fallack→fallback, comment cleanup

### DIFF
--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -844,7 +844,7 @@ namespace srouter::handlers
             }
             catch (const std::exception& e)
             {
-                log::warning(logcat, "An error occured processing fetched rc response: {}", e.what());
+                log::warning(logcat, "An error occurred processing fetched rc response: {}", e.what());
             }
 
             if (rc)

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -298,7 +298,7 @@ namespace srouter
             // Initiates a session to the given remote client or snode address.  Calls
             // `on_attempted` when the connection is either established (immediately, if a session
             // to the target is already established) or when the connection attempt times out (the
-            // caller can check `session.is_established()` to figure out which one occured).
+            // caller can check `session.is_established()` to figure out which one occurred).
             //
             // The timeout, if omitted/nullopt, defaults to the [paths]build-timeout config option.
             //

--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -754,7 +754,7 @@ namespace srouter::link
         }
         catch (const path::TransitHopError& e)
         {
-            log::warning(logcat, "An error occured during path build request handling: {}", e.what());
+            log::warning(logcat, "An error occurred during path build request handling: {}", e.what());
             return m.respond(messages::serialize_status_response(e.error_code), true);
         }
     }

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1826,7 +1826,7 @@ namespace srouter::session
             log::debug(
                 logcat,
                 "Received session accept message for established session, likely a path switch failed because the "
-                "remote restarted, but it accepted our fallack session init.");
+                "remote restarted, but it accepted our fallback session init.");
 
         // reset these so that if this parsing fails we trigger a new session init:
         _is_established = false;

--- a/src/session/session.hpp
+++ b/src/session/session.hpp
@@ -433,7 +433,7 @@ namespace srouter
             // void stop_session() override;
 
             // Calls the given callback with the session when it becomes established, or after
-            // timing out.  (The callback can check which case occured via `.is_established()` on
+            // timing out.  (The callback can check which case occurred via `.is_established()` on
             // the argument).  If the session is already established when this is called then it is
             // fired immediately (before returning).
             //


### PR DESCRIPTION
## Summary

- `occured` → `occurred` (4 instances: session.cpp, session.hpp, link_manager.cpp)
- `fallack` → `fallback` (session.cpp)
- comment cleanup (tcp.cpp)