### PR TITLE
Fix shutdown issues found in libsession

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -87,7 +87,7 @@ namespace srouter
         // it is expected to wait on the future.
         if (running.exchange(false))
         {
-            stop();
+            router->stop();
             wait();
         }
 

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -188,7 +188,13 @@ namespace srouter::handlers
         for (auto& s : std::views::values(_sessions))
             s->close(send_close);
 
-        _sessions.clear();
+        // Note: we intentionally do NOT clear _sessions here.  Session objects (which are also
+        // PathHandlers) may still be referenced by pending QUIC stream callbacks (e.g. path build
+        // timeouts) that fire asynchronously after this stop() call returns.  Clearing the sessions
+        // here would free those PathHandler objects while their callbacks are still queued, leading
+        // to use-after-free.  Instead, we let _sessions be cleaned up naturally when this
+        // SessionEndpoint is destroyed (which happens during `delete router`, after all such
+        // callbacks have been drained from the event loop).
         _session_tags.clear();
 
         path::PathHandler::stop();


### PR DESCRIPTION
1) The `Context` destructor called stop(), but *after* setting running
   to false, which short-circuited stop() and means router->stop() was
   never called.  That then meant that the `wait()` call would hang
   forever because no underlying router->stop() call was ever made.

2) Fix segfault triggered by SessionEndpoint::stop():
   `_sessions.clear()` freed OutboundRelaySession objects but they can
   still have pending send_path_build callbacks still referencing
   `this`.  If those fire before the job queue gets torn down, it's
   a dangling pointer.

   This fixes it by deferring _session cleanup to happen later: instead
   of clearing it in stop(), this lets cleanup happen later (during
   object destruction) so that we keep the objects alive until the job
   queue has been cleaned up so that if they fire in between nothing bad
   happens.