### PR TITLE
Make suggested_mtu useful

### DIFF
--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -48,12 +48,14 @@ namespace session::router
         /// destination through session_router.
         uint16_t local_port;
 
-        /// A suggested maximum MTU for the connection.  If the application supports a configurable
-        /// MTU, this value is the recommended value that avoids some additional overhead from
-        /// packet splitting, which can slightly reduce latency and jitter.  If the application
-        /// doesn't support MTU configuration then this value can simply be ignored and Session
-        /// Router will split any "too large" packets into two.
-        uint16_t suggested_mtu;
+        /// A suggested maximum payload size for the tunnel.  If the application supports a
+        /// configurable payload size, using this value avoids additional overhead from packet
+        /// splitting, which can slightly reduce latency and jitter.  nullopt means the outer
+        /// connection's MTU is unknown (PMTUD without a cap); the application should use its
+        /// own default.  If the application doesn't support payload size configuration then
+        /// this value can simply be ignored and Session Router will split any "too large"
+        /// packets into two.
+        std::optional<uint16_t> suggested_mtu;
     };
 
     using snode_path = std::vector<std::pair<std::string, std::string>>;

--- a/src/link/endpoint.hpp
+++ b/src/link/endpoint.hpp
@@ -130,6 +130,9 @@ namespace srouter::link
         std::shared_ptr<bool> canary = std::make_shared<bool>(true);
 
       public:
+        // Returns the max UDP payload cap configured on the QUIC endpoint, if any.
+        std::optional<size_t> get_max_udp_payload() const { return endpoint->get_max_udp_payload(); }
+
         void start_tickers();
 
         // Returns the connection to the given relay.  If there are established connections in both

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -1,5 +1,6 @@
 #include "address/address.hpp"
 #include "config/config.hpp"
+#include "link/endpoint.hpp"
 #include "net/id.hpp"
 #include "nodedb.hpp"
 #include "router/router.hpp"
@@ -93,12 +94,23 @@ namespace session::router
 
         auto [local_port, session] = context->router->session_endpoint().map_udp_remote_port(netaddr, dest_port);
 
+        // Total tunnel overhead from outer UDP payload to inner payload:
+        // outer QUIC packet framing (44) + path onion (41) + session encryption (37)
+        // + IPv6+UDP wrapping (48) = 170 bytes.
+        constexpr size_t TUNNEL_OVERHEAD = 170;
+
+        // If the outer endpoint has a max UDP payload cap, we can compute the suggested inner
+        // payload size.  Otherwise (uncapped PMTUD), suggested_mtu is nullopt.
+        std::optional<uint16_t> suggested_mtu;
+        if (auto outer_max = context->router->link_endpoint().get_max_udp_payload();
+            outer_max && *outer_max > TUNNEL_OVERHEAD)
+            suggested_mtu = *outer_max - TUNNEL_OVERHEAD;
+
         tunnel_info ti{
             .remote = netaddr.to_string(),
             .remote_port = dest_port,
             .local_port = local_port,
-            // TODO FIXME: 1200 here is just a placeholder, we should be able to pick something better!
-            .suggested_mtu = 1200};
+            .suggested_mtu = suggested_mtu};
 
         if (session->is_established())
         {


### PR DESCRIPTION
It was just an always-1200 stub; this actually tries to give a more useful value now (based on what the mtu max from the Endpoint, if it has one).

~~(DO NOT MERGE YET: needs to be rebased once https://github.com/session-foundation/libquic/pull/13 is merged)~~