### PR TITLE
Split into core + full libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,9 +246,6 @@ target_compile_features(session-router-base INTERFACE cxx_std_20)
 
 add_library(session-router-base-internal INTERFACE)
 target_include_directories(session-router-base-internal INTERFACE include/session_router)
-if(NOT SROUTER_FULL)
-  target_compile_definitions(session-router-base-internal INTERFACE SROUTER_EMBEDDED_ONLY)
-endif()
 
 target_link_libraries(session-router-base-internal INTERFACE session-router-base-internal_warnings)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,14 @@ target_link_libraries(session-router-base INTERFACE oxen::quic oxen::logging nlo
 
 target_compile_features(session-router-base INTERFACE cxx_std_20)
 
+# Interface carrying the full-only external dependencies (oxenmq/libzmq, libunbound).  Only the full
+# libraries link this, which keeps those dependencies off the core libraries' link line entirely
+# (rather than relying on --as-needed to drop them).
+add_library(session-router-base-full INTERFACE)
+if(SROUTER_FULL)
+  target_link_libraries(session-router-base-full INTERFACE sessiondep::libunbound oxenmq::oxenmq)
+endif()
+
 add_library(session-router-base-internal INTERFACE)
 target_include_directories(session-router-base-internal INTERFACE include/session_router)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,30 @@ function(session_router_add_library libname)
     enable_lto(${libname})
 endfunction()
 
+# Link the given internal (static) component libraries into `target`.
+#
+# For a SHARED aggregate the components are whole-archived (all object files included, not just the
+# referenced ones) so the resulting .so is self-complete -- nothing in the aggregate's own translation
+# unit references the component objects, so otherwise the linker would prune them.  This uses the
+# portable $<LINK_LIBRARY:WHOLE_ARCHIVE> on CMake >= 3.24 (which maps to --whole-archive / -force_load /
+# /WHOLEARCHIVE per linker), falling back to the GNU-ld --whole-archive flag on older CMake (so pre-3.24
+# shared builds require a GNU-compatible linker).
+#
+# For a STATIC aggregate whole-archiving is neither needed nor wanted: consumers cherry-pick from the
+# component archives at their final link.  (It must be avoided here -- for a static library the PRIVATE
+# link items propagate to every executable that links the aggregate, which would both bloat those
+# executables and put the WHOLE_ARCHIVE feature on their link lines where it collides with the same
+# components arriving via ordinary transitive links.)
+function(srouter_link_whole target)
+  if(NOT BUILD_SHARED_LIBS)
+    target_link_libraries(${target} PRIVATE ${ARGN})
+  elseif(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    target_link_libraries(${target} PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${ARGN}>")
+  else()
+    target_link_libraries(${target} PRIVATE -Wl,--whole-archive ${ARGN} -Wl,--no-whole-archive)
+  endif()
+endfunction()
+
 session_router_add_library(session-router-cryptography
   crypto/crypto.cpp
   crypto/key_manager.cpp
@@ -34,10 +58,6 @@ session_router_add_library(session-router-core-utils
   messages/common.cpp
 )
 
-if (SROUTER_FULL)
-  target_sources(session-router-core-utils PRIVATE handlers/tun.cpp vpn/egres_packet_router.cpp)
-endif()
-
 session_router_add_library(session-router-core
   context.cpp
   
@@ -49,14 +69,6 @@ session_router_add_library(session-router-core
 
   session/session.cpp
 )
-
-if (SROUTER_FULL)
-  target_sources(session-router-core
-    PRIVATE
-    router/route_poker.cpp
-    consensus/reachability_testing.cpp
-  )
-endif()
 
 if (SROUTER_FULL)
   session_router_add_library(session-router-rpc
@@ -74,12 +86,21 @@ if(SROUTER_FULL)
   # installs full-only overrides (native service manager, stricter config validators, ...) over their
   # core defaults.  A full application must call it early in main().  This is also where the phase-4
   # full-backend factory will live.
+  # Full-only concrete implementations behind the core interfaces (constructed via the backend
+  # hooks), plus the srouter::full::initialize() entry point.  Relocated here out of the core
+  # libraries so the core stays free of the platform/vpn layer.
   session_router_add_library(session-router-full
     full/init.cpp
     full/rpc_backend.cpp
+
+    handlers/tun.cpp
+    vpn/egres_packet_router.cpp
+    router/route_poker.cpp
+    consensus/reachability_testing.cpp
   )
   target_link_libraries(session-router-full PRIVATE
-    session-router-core session-router-dns session-router-platform session-router-rpc)
+    session-router-core session-router-dns session-router-exit-auth
+    session-router-platform session-router-rpc session-router-base-full)
 endif()
 
 # config, crypto, timeplace, nodedb, net, router
@@ -123,7 +144,7 @@ session_router_add_library(session-router-addressing
   ev/tcp.cpp
 )
 
-session_router_add_library(session-router-dns
+session_router_add_library(session-router-dns-data
   dns/srv_data.cpp
 )
 
@@ -168,9 +189,10 @@ if (SROUTER_FULL)
     target_sources(session-router-platform PRIVATE util/nop_service_manager.cpp)
   endif()
 
-  # session-router-dns is the dns parsing and hooking library that we use to
-  # parse modify and reconstitute dns wire proto, dns queries and RR
-  target_sources(session-router-dns PRIVATE
+  # session-router-dns is the (full-only) dns parsing and hooking library that we use to parse,
+  # modify and reconstitute dns wire proto, dns queries and RR.  It is kept separate from the core
+  # session-router-dns-data (which is just the srv_data stub) so that libunbound stays out of core.
+  session_router_add_library(session-router-dns
     dns/encode.cpp
     dns/handler.cpp
     dns/listener.cpp
@@ -185,6 +207,9 @@ if (SROUTER_FULL)
   if(WITH_SYSTEMD)
     target_sources(session-router-dns PRIVATE dns/nm_platform.cpp dns/sd_platform.cpp)
   endif()
+  target_link_libraries(session-router-dns
+    PUBLIC session-router-dns-data session-router-platform session-router-base-full
+    PRIVATE sessiondep::libevent_core)
 endif()
 
 # session-router-nodedb holds all types and logic for storing parsing and constructing
@@ -231,9 +256,9 @@ endif()
 
 # Link libraries to their internals
 target_link_libraries(session-router-nodedb PUBLIC session-router-addressing session-router-cryptography)
-target_link_libraries(session-router-contact PUBLIC session-router-dns)
+target_link_libraries(session-router-contact PUBLIC session-router-dns-data)
 if(SROUTER_FULL)
-  target_link_libraries(session-router-rpc PUBLIC session-router-contact session-router-conf)
+  target_link_libraries(session-router-rpc PUBLIC session-router-contact session-router-conf session-router-base-full)
 endif()
 target_link_libraries(session-router-addressing
     PUBLIC
@@ -243,23 +268,16 @@ target_link_libraries(session-router-addressing
     session-router-ip
     PRIVATE
     sessiondep::libevent_core
-    sessiondep::libzstd
 )
 target_link_libraries(session-router-conf PUBLIC session-router-cryptography session-router-addressing)
 if(SROUTER_FULL)
   target_link_libraries(session-router-platform PUBLIC session-router-cryptography session-router-ip)
-  target_link_libraries(session-router-conf PUBLIC session-router-exit-auth)
 endif()
-target_link_libraries(session-router-dns
+target_link_libraries(session-router-dns-data
   PUBLIC
   session-router-cryptography
   session-router-conf
-  PRIVATE
-  sessiondep::libevent_core
 )
-if(SROUTER_FULL)
-  target_link_libraries(session-router-dns PUBLIC session-router-platform)
-endif()
 
 target_link_libraries(session-router-path
   PUBLIC
@@ -267,18 +285,10 @@ target_link_libraries(session-router-path
 )
 
 target_link_libraries(session-router-core-utils 
-  PUBLIC 
+  PUBLIC
   session-router-conf
-  session-router-dns
+  session-router-dns-data
 )
-
-if(SROUTER_FULL)
-  target_link_libraries(session-router-core-utils
-    PUBLIC
-    session-router-rpc
-    session-router-platform
-  )
-endif()
 
 target_link_libraries(session-router-cryptography
   PRIVATE
@@ -294,6 +304,8 @@ endif()
 target_link_libraries(session-router-utils
   PUBLIC
   session-router-cryptography
+  PRIVATE
+  sessiondep::libzstd
 )
 
 target_link_libraries(session-router-core 
@@ -304,9 +316,6 @@ target_link_libraries(session-router-core
   PRIVATE
   sessiondep::libevent_core
 )
-if(SROUTER_FULL)
-  target_link_libraries(session-router-core PUBLIC session-router-exit-auth)
-endif()
 
 
 target_link_libraries(session-router-base 
@@ -321,33 +330,75 @@ target_link_libraries(session-router-base
 )
 
 
+
+
+
+# Core library (libsessionrouter-core.so): the embedded API plus the core component libraries and no
+# more.  This is what an embedded consumer -- e.g. libsession-util built with -DSROUTER_FULL=OFF --
+# links against; it has no dependency on oxenmq/libunbound or the rpc/platform layer.
+add_library(libsessionrouter-core session_router.cpp)
+srouter_link_whole(libsessionrouter-core
+  session-router-addressing
+  session-router-conf
+  session-router-contact
+  session-router-core
+  session-router-core-utils
+  session-router-cryptography
+  session-router-dns-data
+  session-router-ip
+  session-router-nodedb
+  session-router-path
+  session-router-utils)
+target_link_libraries(libsessionrouter-core PUBLIC session-router-base)
+target_include_directories(libsessionrouter-core PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+set_target_properties(libsessionrouter-core PROPERTIES OUTPUT_NAME sessionrouter-core)
+add_library(session-router::core ALIAS libsessionrouter-core)
+
+# Full library (libsessionrouter.so): the full-only component libraries layered on top of, and linking
+# to, the core library.  This is what the daemon (and any full client/relay application) links.
 if(SROUTER_FULL)
-  target_link_libraries(session-router-base INTERFACE sessiondep::libunbound oxenmq::oxenmq)
+  add_library(libsessionrouter full/lib.cpp)
+  srouter_link_whole(libsessionrouter
+    session-router-full
+    session-router-rpc
+    session-router-platform
+    session-router-exit-auth
+    session-router-dns)
+  target_link_libraries(libsessionrouter PUBLIC libsessionrouter-core PRIVATE session-router-base-full)
+  set_target_properties(libsessionrouter PROPERTIES OUTPUT_NAME sessionrouter)
+  add_library(session-router::full ALIAS libsessionrouter)
+  add_library(session-router::libsessionrouter ALIAS libsessionrouter)  # backwards-compat alias
+  if(WIN32)
+    target_link_libraries(libsessionrouter PUBLIC ws2_32 iphlpapi -fstack-protector)
+  endif()
 endif()
 
-
-
-add_library(libsessionrouter session_router.cpp)
-target_link_libraries(libsessionrouter PUBLIC session-router-core session-router-base)
-target_include_directories(libsessionrouter PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-
-set_target_properties(libsessionrouter PROPERTIES OUTPUT_NAME session-router)
-
 if(BUILD_SHARED_LIBS AND SROUTER_VERSION_SO)
-  set_target_properties(libsessionrouter PROPERTIES
+  set(_srtr_libs libsessionrouter-core)
+  if(SROUTER_FULL)
+    list(APPEND _srtr_libs libsessionrouter)
+  endif()
+  set_target_properties(${_srtr_libs} PROPERTIES
     VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
     SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 endif()
 
-if(WIN32)
-  target_link_libraries(libsessionrouter PUBLIC ws2_32 iphlpapi -fstack-protector)
-  install(TARGETS libsessionrouter DESTINATION bin COMPONENT libsessionrouter)
-elseif(NOT APPLE)
-  include(GNUInstallDirs)
-  install(TARGETS libsessionrouter LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libsessionrouter)
+if(NOT APPLE)
+  if(WIN32)
+    set(_srtr_lib_dest bin)
+    set(_srtr_lib_kind RUNTIME)
+  else()
+    include(GNUInstallDirs)
+    set(_srtr_lib_dest ${CMAKE_INSTALL_LIBDIR})
+    set(_srtr_lib_kind LIBRARY)
+  endif()
+  install(TARGETS libsessionrouter-core ${_srtr_lib_kind} DESTINATION ${_srtr_lib_dest}
+    COMPONENT libsessionrouter-core)
+  if(SROUTER_FULL)
+    install(TARGETS libsessionrouter ${_srtr_lib_kind} DESTINATION ${_srtr_lib_dest}
+      COMPONENT libsessionrouter)
+  endif()
 endif()
-
-add_library(session-router::libsessionrouter ALIAS libsessionrouter)
 
 file(GLOB_RECURSE docs_SRC */*.hpp *.hpp)
 set(DOCS_SRC ${docs_SRC} PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,8 +76,10 @@ if(SROUTER_FULL)
   # full-backend factory will live.
   session_router_add_library(session-router-full
     full/init.cpp
+    full/rpc_backend.cpp
   )
-  target_link_libraries(session-router-full PRIVATE session-router-platform session-router-rpc)
+  target_link_libraries(session-router-full PRIVATE
+    session-router-core session-router-platform session-router-rpc)
 endif()
 
 # config, crypto, timeplace, nodedb, net, router

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,10 +62,22 @@ if (SROUTER_FULL)
   session_router_add_library(session-router-rpc
     rpc/json_binary_proxy.cpp
     rpc/json_conversions.cpp
+    rpc/config_validation.cpp
     rpc/oxend_rpc.cpp
     rpc/rpc_request_parser.cpp
     rpc/rpc_server.cpp
   )
+endif()
+
+if(SROUTER_FULL)
+  # Full (non-embedded) application support: the single srouter::full::initialize() entry point that
+  # installs full-only overrides (native service manager, stricter config validators, ...) over their
+  # core defaults.  A full application must call it early in main().  This is also where the phase-4
+  # full-backend factory will live.
+  session_router_add_library(session-router-full
+    full/init.cpp
+  )
+  target_link_libraries(session-router-full PRIVATE session-router-platform session-router-rpc)
 endif()
 
 # config, crypto, timeplace, nodedb, net, router
@@ -74,6 +86,7 @@ session_router_add_library(session-router-utils
   util/cleared.cpp
   util/file.cpp
   util/logging.cpp
+  util/service_manager.cpp
   util/str.cpp
   util/thread/queue_manager.cpp  
   util/thread/threading.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,7 @@ if(SROUTER_FULL)
     full/rpc_backend.cpp
   )
   target_link_libraries(session-router-full PRIVATE
-    session-router-core session-router-platform session-router-rpc)
+    session-router-core session-router-dns session-router-platform session-router-rpc)
 endif()
 
 # config, crypto, timeplace, nodedb, net, router

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -1,6 +1,6 @@
 #include "auth.hpp"
 
-#include <oxenmq/oxenmq.h>
+#include <unordered_map>
 
 namespace srouter::auth
 {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -14,10 +14,6 @@
 #include <filesystem>
 #include <stdexcept>
 
-#ifndef SROUTER_EMBEDDED_ONLY
-#include <oxenmq/address.h>
-#endif
-
 namespace srouter
 {
     static auto logcat = log::Cat("config");
@@ -1176,9 +1172,14 @@ namespace srouter
                 "    rpc=tcp://127.0.0.1:5678",
             },
             [this](std::string arg) {
-#ifndef SROUTER_EMBEDDED_ONLY
-                oxenmq::address test_valid{arg};
-#endif
+                // The full library installs a stricter oxenmq-based validator (see
+                // config::install_full_config_validators); embedded/core-only builds fall back to a
+                // cheap scheme check so we don't pull oxenmq into the core config library.
+                if (config::oxend_rpc_addr_validator)
+                    config::oxend_rpc_addr_validator(arg);
+                else if (arg.find("://") == std::string::npos)
+                    throw std::invalid_argument{
+                        "Invalid [oxend]:rpc address '{}': expected a scheme such as ipc:// or tcp://"_format(arg)};
                 rpc_addr = std::move(arg);
             });
     }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1581,11 +1581,6 @@ namespace srouter
     Config::Config(config::Type type, std::string ini, std::filesystem::path conf_dir, std::string config_for_debug)
         : type{type}, defs{type, std::move(conf_dir)}, parser{std::move(config_for_debug)}
     {
-#ifdef SROUTER_EMBEDDED_ONLY
-        if (type != Type::EmbeddedClient)
-            throw std::runtime_error{
-                "This Session Router build only supports embedded clients, not {}"_format(to_string(type))};
-#endif
         for (ConfigBase* c : std::initializer_list<ConfigBase*>{
                  &router, &exit, &network, &paths, &dns, &links, &api, &oxend, &bootstrap, &logging})
             c->define_config_options(defs);

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -23,6 +23,20 @@
 #include <unordered_set>
 #include <vector>
 
+namespace srouter::config
+{
+    // Optional stricter validator for the [oxend]:rpc address, installed by the full library (which
+    // parses it via oxenmq::address).  Null in embedded/core-only builds, where config.cpp falls
+    // back to a cheap scheme check so oxenmq stays out of the core config library.  Installed via
+    // install_full_config_validators().
+    inline void (*oxend_rpc_addr_validator)(const std::string&) = nullptr;
+
+    // Installs the full library's stricter config validators over the core defaults.  Defined in the
+    // full (rpc) library; invoked by srouter::full::initialize().
+    void install_full_config_validators();
+
+}  // namespace srouter::config
+
 namespace srouter
 {
     using SectionValues = srouter::ConfigParser::SectionValues;

--- a/src/consensus/reachability.hpp
+++ b/src/consensus/reachability.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace srouter::consensus
+{
+    // Core-side interface for reachability (service-node uptime) testing.  Router holds and drives an
+    // IReachability; the concrete implementation (reachability_testing, a relay-only full component)
+    // is constructed via the full-only seam.  In embedded/core-only builds Router never constructs one
+    // (the pointer stays null), so core references only this interface.
+    struct IReachability
+    {
+        virtual ~IReachability() = default;
+
+        // Start/stop the reachability testing ticker.
+        virtual void start() = 0;
+        virtual void stop() = 0;
+
+        // Called when this router receives an incoming ping test request.
+        virtual void incoming_ping() = 0;
+    };
+
+}  // namespace srouter::consensus

--- a/src/consensus/reachability_testing.cpp
+++ b/src/consensus/reachability_testing.cpp
@@ -159,8 +159,9 @@ namespace srouter::consensus
         }
     }
 
-    void reachability_testing::incoming_ping(const time_point_t& now)
+    void reachability_testing::incoming_ping()
     {
+        auto now = clock_t::now();
         last.last_test = now;
 
         // If we had previous logged about a failure then log about the success immediately (rather

--- a/src/consensus/reachability_testing.hpp
+++ b/src/consensus/reachability_testing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "consensus/reachability.hpp"
 #include "contact/router_id.hpp"
 #include "util/time.hpp"
 
@@ -50,7 +51,7 @@ namespace srouter::consensus
     using fseconds = std::chrono::duration<float, std::chrono::seconds::period>;
     using fminutes = std::chrono::duration<float, std::chrono::minutes::period>;
 
-    class reachability_testing
+    class reachability_testing : public IReachability
     {
       public:
         // How often we tick the timer to perform one new random test and check whether we need to
@@ -123,8 +124,8 @@ namespace srouter::consensus
         explicit reachability_testing(Router& r);
 
         // Called by router when it is starting/stopping to start/stop our ticker.
-        void start();
-        void stop();
+        void start() override;
+        void stop() override;
 
         // Runs a tick iteration.
         void tick();
@@ -151,7 +152,7 @@ namespace srouter::consensus
         void remove_node_from_failing(const RouterID& pk);
 
         // Called when this router receives an incoming ping test request
-        void incoming_ping(const time_point_t& now = clock_t::now());
+        void incoming_ping() override;
 
         // Check whether we received incoming pings recently
         void check_incoming_tests(const time_point_t& now = clock_t::now());

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -51,15 +51,14 @@ namespace srouter
         lifetime_waiter = done_promise.get_future();
 
         std::shared_ptr<srouter::vpn::Platform> plat;
-#ifndef SROUTER_EMBEDDED_ONLY
         if (!embedded)
         {
             log::debug(logcat, "Initializing platform code...");
-            plat = vpn::MakeNativePlatform(this);
+            if (vpn::make_native_platform)
+                plat = vpn::make_native_platform(this);
             if (!plat)
                 throw std::runtime_error{"This platform is not currently supported!"};
         }
-#endif
 
         log::debug(logcat, "Starting main router...");
         try

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -110,11 +110,9 @@ namespace srouter
 
     Context::Context(bool embedded, Config conf, std::shared_ptr<oxen::quic::Loop> loop) : embedded{embedded}
     {
-#ifndef SROUTER_EMBEDDED_ONLY
         // service_manager is a global and context isnt
         if (!embedded)
             srouter::sys::service_manager->give_context(this);
-#endif
         start(std::move(conf), std::move(loop));
     }
 

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -5,7 +5,7 @@ if(APPLE)
 else()
   add_executable(session-router session_router.cpp)
 endif()
-target_link_libraries(session-router PRIVATE libsessionrouter CLI11::CLI11)
+target_link_libraries(session-router PRIVATE session-router-full libsessionrouter CLI11::CLI11)
 enable_lto(session-router)
 
 add_executable(session-router-cntrl session-router-cntrl.cpp utils.cpp)

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -5,15 +5,15 @@ if(APPLE)
 else()
   add_executable(session-router session_router.cpp)
 endif()
-target_link_libraries(session-router PRIVATE session-router-full libsessionrouter CLI11::CLI11)
+target_link_libraries(session-router PRIVATE session-router::full CLI11::CLI11)
 enable_lto(session-router)
 
 add_executable(session-router-cntrl session-router-cntrl.cpp utils.cpp)
-target_link_libraries(session-router-cntrl PRIVATE session-router-base CLI11::CLI11)
+target_link_libraries(session-router-cntrl PRIVATE session-router-base session-router-base-full CLI11::CLI11)
 enable_lto(session-router-cntrl)
 
 add_executable(session-router-config session-router-config.cpp)
-target_link_libraries(session-router-config PRIVATE session-router-conf CLI11::CLI11)
+target_link_libraries(session-router-config PRIVATE session-router-conf session-router-base-full CLI11::CLI11)
 enable_lto(session-router-config)
 
 set(exetargets session-router session-router-cntrl session-router-config)

--- a/src/daemon/session_router.cpp
+++ b/src/daemon/session_router.cpp
@@ -1,6 +1,7 @@
 #include "config/config.hpp"  // for ensure_config
 #include "constants/platform.hpp"
 #include "constants/version.hpp"
+#include "full/init.hpp"
 #include "util/exceptions.hpp"
 #include "util/thread/threading.hpp"
 
@@ -495,6 +496,11 @@ int main(int argc, char* argv[])
     oxen::log::add_sink(srouter::log::Type::Print, "stderr");
     oxen::log::reset_level(srouter::log::Level::info);
     // oxen::log::set_level("quic", oxen::log::Level::info);
+
+    // Set up full (non-embedded) application support (native service manager, stricter config
+    // validators, ...).  Must happen before config is loaded and before the Context is constructed
+    // (which calls give_context()) and, on win32, before the service control dispatcher runs.
+    srouter::full::initialize();
 
     // TODO FIXME: this seems to be segfaulting?
     // srouter::logRingBuffer = std::make_shared<srouter::log::RingBufferSink>(100);

--- a/src/dns/handler.cpp
+++ b/src/dns/handler.cpp
@@ -13,10 +13,6 @@
 
 namespace srouter::dns
 {
-#ifdef SROUTER_EMBEDDED_ONLY
-    static_assert(false, "dns::RequestHandler requires a full lokinet build!");
-#endif
-
     namespace
     {
         auto logcat = log::Cat("dns");

--- a/src/full/init.cpp
+++ b/src/full/init.cpp
@@ -9,6 +9,7 @@ namespace srouter::full
     {
         sys::install_native_service_manager();
         config::install_full_config_validators();
+        install_rpc_backend();
     }
 
 }  // namespace srouter::full

--- a/src/full/init.cpp
+++ b/src/full/init.cpp
@@ -1,0 +1,14 @@
+#include "full/init.hpp"
+
+#include "config/config.hpp"
+#include "util/service_manager.hpp"
+
+namespace srouter::full
+{
+    void initialize()
+    {
+        sys::install_native_service_manager();
+        config::install_full_config_validators();
+    }
+
+}  // namespace srouter::full

--- a/src/full/init.cpp
+++ b/src/full/init.cpp
@@ -1,7 +1,9 @@
 #include "full/init.hpp"
 
 #include "config/config.hpp"
+#include "net/platform.hpp"
 #include "util/service_manager.hpp"
+#include "vpn/platform.hpp"
 
 namespace srouter::full
 {
@@ -10,6 +12,8 @@ namespace srouter::full
         sys::install_native_service_manager();
         config::install_full_config_validators();
         install_rpc_backend();
+        net::native_net_platform = net::Platform::Default_ptr();
+        vpn::make_native_platform = &vpn::MakeNativePlatform;
     }
 
 }  // namespace srouter::full

--- a/src/full/init.hpp
+++ b/src/full/init.hpp
@@ -13,4 +13,8 @@ namespace srouter::full
     // static initialisation, is deterministic.
     void initialize();
 
+    // Installs the rpc/oxend/omq/reachability construction hooks (RpcBackendHooks) so Router can
+    // build those full-only objects.  Implementation detail of initialize(); not called directly.
+    void install_rpc_backend();
+
 }  // namespace srouter::full

--- a/src/full/init.hpp
+++ b/src/full/init.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace srouter::full
+{
+    // Full (non-embedded) application setup.  Installs the full library's overrides -- the native
+    // service manager, stricter config validators, and (in future) other full-only hooks -- over the
+    // no-op/lightweight defaults that the core library provides.
+    //
+    // A full application (e.g. the session-router daemon) MUST call this exactly once, early in
+    // main(), before it loads any config or constructs a Context.  It is deliberately a plain call
+    // rather than static-init registration: the core defaults are dynamically initialised, so a
+    // static-init override would race with them across translation units; running here, after all
+    // static initialisation, is deterministic.
+    void initialize();
+
+}  // namespace srouter::full

--- a/src/full/lib.cpp
+++ b/src/full/lib.cpp
@@ -1,0 +1,10 @@
+// Aggregate translation unit for the full session-router library (libsessionrouter).
+//
+// The full library's contents come entirely from the full component libraries it links (the backend,
+// rpc, platform, exit-auth, full dns, ...) layered on top of the core library.  This translation unit
+// exists only to give the aggregate a source file to build from.
+
+namespace srouter::full
+{
+    // (intentionally empty)
+}

--- a/src/full/rpc_backend.cpp
+++ b/src/full/rpc_backend.cpp
@@ -1,15 +1,23 @@
 #include "router/rpc_backend.hpp"
 
 #include "consensus/reachability_testing.hpp"
+#include "dns/listener.hpp"
+#include "handlers/tun.hpp"
+#include "router/router.hpp"
 #include "rpc/oxend_rpc.hpp"
 #include "rpc/rpc_server.hpp"
+#include "util/logging.hpp"
 
+#include <fmt/ranges.h>
 #include <oxenmq/oxenmq.h>
 
+#include <exception>
 #include <memory>
 
 namespace srouter::full
 {
+    static auto logcat = log::Cat("full");
+
     namespace
     {
         std::shared_ptr<oxenmq::OxenMQ> make_omq()
@@ -38,12 +46,51 @@ namespace srouter::full
             return std::make_shared<consensus::reachability_testing>(r);
         }
 
+        std::shared_ptr<handlers::ITunnel> make_tun(Router& r)
+        {
+            return r.loop().make_shared<handlers::TunEndpoint>(r);
+        }
+
+        std::shared_ptr<dns::Listener> make_dns(Router& r)
+        {
+            const auto& dns_bind = r.config().dns._listen_addrs;
+            if (dns_bind.empty())
+            {
+                // Allowed (e.g. a service-only client), just unusual.
+                log::warning(
+                    logcat, "[dns]:listen is empty: DNS disabled.  Making outbound paths will not be possible");
+                return nullptr;
+            }
+
+            std::shared_ptr<dns::Listener> listener;
+            try
+            {
+                for (const auto& addr : dns_bind)
+                {
+                    if (!listener)
+                        listener = r.loop().make_shared<dns::Listener>(r, addr);
+                    else
+                        listener->listen(r.loop(), addr);
+
+                    log::info(logcat, "DNS listening on {} port {}", addr.host(), listener->last_port);
+                }
+            }
+            catch (const std::exception& e)
+            {
+                log::error(logcat, "Failed to initialize DNS listener on {}: {}", fmt::join(dns_bind, ","), e.what());
+                throw;
+            }
+            return listener;
+        }
+
         const RpcBackendHooks hooks{
             .make_omq = &make_omq,
             .start_omq = &start_omq,
             .make_oxend = &make_oxend,
             .make_rpc_server = &make_rpc_server,
             .make_reachability = &make_reachability,
+            .make_tun = &make_tun,
+            .make_dns = &make_dns,
         };
     }  // namespace
 

--- a/src/full/rpc_backend.cpp
+++ b/src/full/rpc_backend.cpp
@@ -1,0 +1,52 @@
+#include "router/rpc_backend.hpp"
+
+#include "consensus/reachability_testing.hpp"
+#include "rpc/oxend_rpc.hpp"
+#include "rpc/rpc_server.hpp"
+
+#include <oxenmq/oxenmq.h>
+
+#include <memory>
+
+namespace srouter::full
+{
+    namespace
+    {
+        std::shared_ptr<oxenmq::OxenMQ> make_omq()
+        {
+            auto omq = std::make_shared<oxenmq::OxenMQ>();
+            // Raise the max message size (no limit) so that syncing the registered relay list from
+            // oxend -- which can exceed the default 1MB -- doesn't get the connection closed.
+            omq->MAX_MSG_SIZE = -1;
+            return omq;
+        }
+
+        void start_omq(oxenmq::OxenMQ& omq) { omq.start(); }
+
+        std::shared_ptr<rpc::IOxendClient> make_oxend(Router& r, oxenmq::OxenMQ& omq)
+        {
+            return std::make_shared<rpc::OxendRPC>(omq, r);
+        }
+
+        std::shared_ptr<rpc::RPCServer> make_rpc_server(Router& r, oxenmq::OxenMQ& omq)
+        {
+            return std::make_shared<rpc::RPCServer>(omq, r);
+        }
+
+        std::shared_ptr<consensus::IReachability> make_reachability(Router& r)
+        {
+            return std::make_shared<consensus::reachability_testing>(r);
+        }
+
+        const RpcBackendHooks hooks{
+            .make_omq = &make_omq,
+            .start_omq = &start_omq,
+            .make_oxend = &make_oxend,
+            .make_rpc_server = &make_rpc_server,
+            .make_reachability = &make_reachability,
+        };
+    }  // namespace
+
+    void install_rpc_backend() { rpc_backend = &hooks; }
+
+}  // namespace srouter::full

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -110,10 +110,8 @@ namespace srouter::handlers
         s->close(send_close);
 
         const auto& remote = s->remote();
-#ifndef SROUTER_EMBEDDED_ONLY
         if (auto& tun = router.tun_endpoint())
             tun->expire(remote);
-#endif
 
         // defer this in case we're in the middle of iterating the container(s)
         // capture a weak_ptr to the session so that if for whatever reason
@@ -1056,7 +1054,6 @@ namespace srouter::handlers
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
-#ifndef SROUTER_EMBEDDED_ONLY
         if (const auto& tun = router.tun_endpoint())
         {
             log::debug(logcat, "Mapping local tun ipv4 for inbound session from {}", s.remote());
@@ -1067,7 +1064,6 @@ namespace srouter::handlers
                 log::warning(logcat, "Mapping unsuccessful; out of available addresses?");
             return addr;
         }
-#endif
 
         // TODO: no tun-based
 
@@ -1078,7 +1074,6 @@ namespace srouter::handlers
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
-#ifndef SROUTER_EMBEDDED_ONLY
         if (const auto& tun = router.tun_endpoint())
         {
             log::debug(logcat, "Successfully mapped inbound session; mapping session to local TUN IPv6");
@@ -1089,7 +1084,6 @@ namespace srouter::handlers
             log::info(logcat, "TUN device successfully mapped session (remote: {}) to local ip: {}", s.remote(), addr);
             return addr;
         }
-#endif
 
         // TODO: if we're not tun-based -- currently not allowing inbound sessions for non-tun
 

--- a/src/handlers/tun.hpp
+++ b/src/handlers/tun.hpp
@@ -2,6 +2,7 @@
 
 #include "address/map.hpp"
 #include "ev/fd_poller.hpp"
+#include "handlers/tun_interface.hpp"
 #include "net/ip_packet.hpp"
 #include "util/thread/threading.hpp"
 #include "vpn/packet_router.hpp"
@@ -11,7 +12,7 @@ namespace srouter::handlers
 {
     inline constexpr auto TUN = "tun"sv;
 
-    class TunEndpoint
+    class TunEndpoint : public ITunnel
     {
       public:
         TunEndpoint(Router& r);
@@ -50,7 +51,7 @@ namespace srouter::handlers
 
         void configure();
 
-        std::string get_if_name() const;
+        std::string get_if_name() const override;
 
         // Returns the Session Router tun IPv4 address
         const ipv4& get_ipv4() const;
@@ -59,12 +60,12 @@ namespace srouter::handlers
 
         // Returns the Session Router tun IPv4/6 network; the address is set to this tun device's
         // local address (i.e. typically the .1 address).
-        const ipv4_net& get_ipv4_network() const;
-        const ipv6_net& get_ipv6_network() const;
+        const ipv4_net& get_ipv4_network() const override;
+        const ipv6_net& get_ipv6_network() const override;
 
         void tick_tun(sys_ms now);
 
-        void stop();
+        void stop() override;
 
         bool is_service_node() const;
 
@@ -77,7 +78,7 @@ namespace srouter::handlers
         void rewrite_and_send_packet(IPPacket&& pkt, const ipv4& src, const ipv4& dest);
         void rewrite_and_send_packet(IPPacket&& pkt, const ipv6& src, const ipv6& dest);
 
-        void handle_inbound_packet(IPPacket pkt, traffic_type type, NetworkAddress remote);
+        void handle_inbound_packet(IPPacket pkt, traffic_type type, NetworkAddress remote) override;
 
         // Handles an inbound packet coming IN from the network
         // bool handle_inbound_packet(IPPacket pkt, NetworkAddress remote, bool is_exit_session, bool
@@ -87,7 +88,7 @@ namespace srouter::handlers
         // Router remote address with it.  If the mapping already exists, this returns the existing
         // IP, otherwise it assigns a new one.  The association persists until unmapped.  Returns
         // the mapped ipv6 address.
-        ipv6 map6(const NetworkAddress& remote);
+        ipv6 map6(const NetworkAddress& remote) override;
 
         // Obtains an available IPv4 address from the tun device and associates the given Session
         // Router remote address with it.  If the mapping already exists, this returns the existing
@@ -98,13 +99,22 @@ namespace srouter::handlers
         // Returns the mapped addresses, or nullptr if an address could not be assigned (i.e.
         // because of IPv4 exhaustion in the allocated tun range, or because this client does not
         // support IPv4 addressing at all).
-        std::optional<ipv4> map4(const NetworkAddress& remote);
+        std::optional<ipv4> map4(const NetworkAddress& remote) override;
 
         // Takes an IPv4 or IPv6 address and returns {addr, true} if the address is a tun address
         // range IP mapped to an address; {nullptr, true} if it is a tun address range IP but
         // without a mapped address; or {nullptr, false} if it is not a tun address range IP.
+        std::pair<std::optional<NetworkAddress>, bool> reverse_lookup(const ipv4& ip) override
+        {
+            return reverse_lookup_impl(ip);
+        }
+        std::pair<std::optional<NetworkAddress>, bool> reverse_lookup(const ipv6& ip) override
+        {
+            return reverse_lookup_impl(ip);
+        }
+
         template <typename IP>
-        std::pair<std::optional<NetworkAddress>, bool> reverse_lookup(const IP& ip)
+        std::pair<std::optional<NetworkAddress>, bool> reverse_lookup_impl(const IP& ip)
             requires std::same_as<IP, ipv4> || std::same_as<IP, ipv6>
         {
             std::pair<std::optional<NetworkAddress>, bool> result;
@@ -125,7 +135,7 @@ namespace srouter::handlers
         // Expires a mapped IP for the given remote from the tun IP map.  The address will be added
         // as the most recently used address, and (if the configured cache size is exceeded) the least
         // recently used address will be forgotten.
-        void expire(const NetworkAddress& remote);
+        void expire(const NetworkAddress& remote) override;
 
         std::optional<net::ExitPolicy> get_exit_policy() const { return _exit_policy; }
 
@@ -140,7 +150,7 @@ namespace srouter::handlers
 
         Router& router() { return _router; }
 
-        void start_poller();
+        void start_poller() override;
 
       private:
         // Stores assigned IP's for each session in/out of this Session Router instance

--- a/src/handlers/tun_interface.hpp
+++ b/src/handlers/tun_interface.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "address/address.hpp"
+#include "address/ip_range.hpp"
+#include "net/ip_packet.hpp"
+#include "net/traffic_type.hpp"
+
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace srouter::handlers
+{
+    // Core-side interface for the TUN endpoint.  Router holds and drives an ITunnel; the concrete
+    // implementation (TunEndpoint, which needs the platform/vpn layer) lives in the full library and
+    // is constructed via the full-only seam.  In embedded/core-only builds Router never constructs one
+    // (the pointer stays null), so core references only this interface -- never the platform code.
+    struct ITunnel
+    {
+        virtual ~ITunnel() = default;
+
+        virtual void start_poller() = 0;
+        virtual void stop() = 0;
+
+        virtual std::string get_if_name() const = 0;
+
+        virtual const ipv4_net& get_ipv4_network() const = 0;
+        virtual const ipv6_net& get_ipv6_network() const = 0;
+
+        virtual void handle_inbound_packet(IPPacket pkt, traffic_type type, NetworkAddress remote) = 0;
+
+        virtual ipv6 map6(const NetworkAddress& remote) = 0;
+        virtual std::optional<ipv4> map4(const NetworkAddress& remote) = 0;
+
+        virtual void expire(const NetworkAddress& remote) = 0;
+
+        virtual std::pair<std::optional<NetworkAddress>, bool> reverse_lookup(const ipv4& ip) = 0;
+        virtual std::pair<std::optional<NetworkAddress>, bool> reverse_lookup(const ipv6& ip) = 0;
+    };
+
+}  // namespace srouter::handlers

--- a/src/link/link_manager.cpp
+++ b/src/link/link_manager.cpp
@@ -34,10 +34,6 @@
 #include <ranges>
 #include <variant>
 
-#ifndef SROUTER_EMBEDDED_ONLY
-#include "rpc/oxend_rpc.hpp"
-#endif
-
 namespace srouter::link
 {
     static auto logcat = srouter::log::Cat("link.manager");
@@ -349,9 +345,9 @@ namespace srouter::link
 
     void Manager::handle_path_resolve_sns(std::span<const std::byte> body, std::function<void(std::string)> respond)
     {
-#ifdef SROUTER_EMBEDDED_ONLY
-        throw std::logic_error{"This Session Router is not a service node!"};
-#else
+        if (!router.oxend())
+            throw std::logic_error{"This Session Router is not a service node!"};
+
         log::trace(logcat, "Received request to publish client contact!");
 
         std::string_view name_hash;
@@ -366,7 +362,6 @@ namespace srouter::link
             return respond(messages::ERROR_RESPONSE);
         }
 
-        assert(router.oxend());
         router.oxend()->lookup_sns_hash(
             name_hash, [respond = std::move(respond)](std::optional<std::pair<std::string, SymmNonce>> maybe_enc) {
                 if (maybe_enc)
@@ -384,7 +379,6 @@ namespace srouter::link
                     respond(messages::NOT_FOUND_RESPONSE);
                 }
             });
-#endif
     }
 
     void Manager::handle_publish_cc(

--- a/src/linux/sd_service_manager.cpp
+++ b/src/linux/sd_service_manager.cpp
@@ -48,6 +48,7 @@ namespace srouter::sys
     };
 
     SD_Manager _manager{};
-    I_SystemLayerManager* const service_manager = &_manager;
+
+    void install_native_service_manager() { service_manager = &_manager; }
 
 }  // namespace srouter::sys

--- a/src/net/platform.hpp
+++ b/src/net/platform.hpp
@@ -55,4 +55,9 @@ namespace srouter::net
         virtual std::optional<int> get_interface_index(ipv6 ip) const = 0;
     };
 
+    // Settable pointer to the platform's native net::Platform singleton, installed by the full
+    // library (srouter::full::initialize) to Platform::Default_ptr().  Null in embedded/core-only
+    // builds; core only dereferences net() on the non-embedded path.
+    inline const Platform* native_net_platform = nullptr;
+
 }  // namespace srouter::net

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -6,7 +6,6 @@
 #include "constants/version.hpp"
 #include "contact/contactdb.hpp"
 #include "crypto/crypto.hpp"
-#include "dns/listener.hpp"
 #include "link/link_manager.hpp"
 #include "nodedb.hpp"
 #include "util/formattable.hpp"
@@ -71,10 +70,8 @@ namespace srouter
 
     void Router::start_tickers()
     {
-#ifndef SROUTER_EMBEDDED_ONLY
         if (_tun)
             _tun->start_poller();
-#endif
 
         if (!embedded())
             _service_stat_ticker = _loop->call_every(SERVICE_MANAGER_REPORT_INTERVAL, [this]() {
@@ -191,12 +188,10 @@ namespace srouter
                 log::set_level(log_global, log::Level::info);
         });
 
-#ifndef SROUTER_EMBEDDED_ONLY
         // re-add rpc log sink if rpc enabled, else free it
         if (_config.api.enable_rpc_server and srouter::logRingBuffer)
             log::add_sink(srouter::logRingBuffer, srouter::log::DEFAULT_PATTERN_MONO);
         else
-#endif
             srouter::logRingBuffer.reset();
     }
 
@@ -530,55 +525,21 @@ namespace srouter
 
         if (!embedded())
         {
-#ifdef SROUTER_EMBEDDED_ONLY
-            log::critical(logcat, "This Session Router build only supports embedded configurations!");
-            throw std::runtime_error{"This Session Router build only supports embedded configurations!"};
-#else
             log::debug(logcat, "Initializing TUN device");
-            _tun = _loop->make_shared<handlers::TunEndpoint>(*this);
+            _tun = rpc_backend->make_tun(*this);
 
             log::info(logcat, "Session Router IPv4 local network is {}", _tun->get_ipv4_network());
             log::info(logcat, "Session Router IPv6 local network is {}", _tun->get_ipv6_network());
 
             // only (full) clients should have DNS, relays have no need for it
             if (!is_service_node)
-            {
-                auto& dns_bind = config().dns._listen_addrs;
-                if (dns_bind.empty())
-                {
-                    // This configuration is allowed (a service-only client might use it), although a bit unusual
-                    log::warning(
-                        logcat, "[dns]:listen is empty: DNS disabled.  Making outbound paths will not be possible");
-                }
-                else
-                {
-                    try
-                    {
-                        for (const auto& addr : dns_bind)
-                        {
-                            if (!_dns)
-                                _dns = _loop->make_shared<dns::Listener>(*this, addr);
-                            else
-                                _dns->listen(loop(), addr);
-
-                            log::info(log_global, "DNS listening on {} port {}", addr.host(), _dns->last_port);
-                        }
-                    }
-                    catch (const std::exception& e)
-                    {
-                        log::error(
-                            logcat, "Failed to initialize DNS listener on {}: {}", fmt::join(dns_bind, ","), e.what());
-                        throw;
-                    }
-                }
-            }
+                _dns = rpc_backend->make_dns(*this);
 
             log::info(
                 log_global,
                 "Session Router internal network: {} on device {}",
                 _tun->get_ipv4_network(),
                 _tun->get_if_name());
-#endif
         }
         else
             log::debug(logcat, "Not initializing TUN device; running as an embedded client");
@@ -703,7 +664,6 @@ namespace srouter
     void Router::_relay_tick([[maybe_unused]] sys_ms now)
     {
         assert(_config.type == config::Type::Relay);
-#ifndef SROUTER_EMBEDDED_ONLY
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
 
         auto steady_now = steady_now_ms();
@@ -741,7 +701,6 @@ namespace srouter
         }
 
         path_context.expire_hops(now);
-#endif
     }
 
     void Router::_client_tick(sys_ms now)
@@ -1018,13 +977,11 @@ namespace srouter
             log::debug(logcat, "closing all connections");
             _link_manager->stop();
 
-#ifndef SROUTER_EMBEDDED_ONLY
             if (_dns)
                 _dns.reset();
 
             if (_tun)
                 _tun->stop();
-#endif
 
             auto rv = _loop_ticker->stop();
             log::debug(logcat, "router loop ticker stopped {}successfully!", rv ? "" : "un");
@@ -1073,29 +1030,23 @@ namespace srouter
 
     std::pair<std::optional<NetworkAddress>, bool> Router::reverse_lookup(const ipv4& addr) const
     {
-#ifndef SROUTER_EMBEDDED_ONLY
         if (_tun)
             return _tun->reverse_lookup(addr);
-#endif
         return {std::nullopt, false};
     }
 
     std::pair<std::optional<NetworkAddress>, bool> Router::reverse_lookup(const ipv6& addr) const
     {
-#ifndef SROUTER_EMBEDDED_ONLY
         if (_tun)
             return _tun->reverse_lookup(addr);
-#endif
         return {std::nullopt, false};
     }
 
     const srouter::net::Platform* Router::net() const
     {
-#ifndef SROUTER_EMBEDDED_ONLY
-        if (!embedded())
-            return srouter::net::Platform::Default_ptr();
-#endif
-        return nullptr;
+        if (embedded())
+            return nullptr;
+        return srouter::net::native_net_platform;
     }
 
 }  // namespace srouter

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -87,12 +87,12 @@ namespace srouter
 #ifndef SROUTER_EMBEDDED_ONLY
         if (_tun)
             _tun->start_poller();
+#endif
 
         if (!embedded())
             _service_stat_ticker = _loop->call_every(SERVICE_MANAGER_REPORT_INTERVAL, [this]() {
                 sys::service_manager->report_periodic_stats(status_line());
             });
-#endif
 
         _node_db->start();
         _contact_db->start_tickers();
@@ -456,10 +456,8 @@ namespace srouter
     void Router::configure()
     {
         log::trace(logcat, "{} called", __PRETTY_FUNCTION__);
-#ifndef SROUTER_EMBEDDED_ONLY
         if (!embedded())
             sys::service_manager->starting();
-#endif
 
         if (_config.exit.exit_enabled and is_service_node)
             throw std::runtime_error{
@@ -869,10 +867,8 @@ namespace srouter
         start_tickers();
         _is_running = true;
 
-#ifndef SROUTER_EMBEDDED_ONLY
         if (!embedded())
             srouter::sys::service_manager->ready();
-#endif
 
         log::info(
             log_global,
@@ -1026,13 +1022,13 @@ namespace srouter
             return;  // Lost a race with something else trying to stop
 
         _jq->call([this] {
-#ifndef SROUTER_EMBEDDED_ONLY
             if (!embedded())
             {
                 log::debug(logcat, "stopping service manager...");
                 srouter::sys::service_manager->stopping();
             }
 
+#ifndef SROUTER_EMBEDDED_ONLY
             if (_router_testing)
                 _router_testing->stop();
 #endif

--- a/src/router/router.cpp
+++ b/src/router/router.cpp
@@ -1,7 +1,6 @@
 #include "router.hpp"
 
 #include "config/config.hpp"
-#include "consensus/reachability_testing.hpp"
 #include "constants/platform.hpp"
 #include "constants/proto.hpp"
 #include "constants/version.hpp"
@@ -21,15 +20,6 @@
 #include <oxen/log.hpp>
 
 #include <chrono>
-
-#ifndef SROUTER_EMBEDDED_ONLY
-#include "handlers/tun.hpp"
-#include "rpc/oxend_rpc.hpp"
-#include "rpc/rpc_server.hpp"
-
-#include <oxenmq/oxenmq.h>
-#endif
-
 #include <cstdlib>
 #include <memory>
 #include <stdexcept>
@@ -57,17 +47,14 @@ namespace srouter
           _contact_db{std::make_unique<ContactDB>(*this)},
           _last_tick{}
     {
-#ifndef SROUTER_EMBEDDED_ONLY
-        // Not actually shared, but unique_ptr would require destructor visibility which
-        // embedded-only won't have:
-        _omq = std::make_shared<oxenmq::OxenMQ>();
-        // for oxend, so we don't close the connection when syncing the registered relay (which can
-        // exceed the defaut 1MB limit).
-        _omq->MAX_MSG_SIZE = -1;
-
-        if (is_service_node)
-            _router_testing = std::make_shared<consensus::reachability_testing>(*this);
-#endif
+        // Full builds install the rpc backend (srouter::full::initialize); in embedded/core-only
+        // builds rpc_backend is null and these stay null (the relay/rpc paths never run).
+        if (rpc_backend)
+        {
+            _omq = rpc_backend->make_omq();
+            if (is_service_node)
+                _router_testing = rpc_backend->make_reachability(*this);
+        }
 
         init_logging();
 
@@ -98,7 +85,6 @@ namespace srouter
         _contact_db->start_tickers();
         _link_endpoint->start_tickers();
 
-#ifndef SROUTER_EMBEDDED_ONLY
         if (is_service_node)
         {
             _oxend->start_pings();
@@ -123,7 +109,6 @@ namespace srouter
                 _router_testing->start();
         }
         else
-#endif
         {
             // Resolve needed ONS values now that we have the necessary things prefigured
             _session_endpoint->resolve_sns_mappings();
@@ -135,7 +120,6 @@ namespace srouter
     void Router::fetch_snode_keys()
     {
         assert(is_service_node);
-#ifndef SROUTER_EMBEDDED_ONLY
 
         our_rc_file = _config.router.data_dir / our_rc_filename;
 
@@ -166,7 +150,6 @@ namespace srouter
                     throw;
             }
         }
-#endif
     }
 
     void Router::init_logging()
@@ -474,29 +457,29 @@ namespace srouter
 
         log::info(log_global, "Operating as a Session Router {}", is_service_node ? "relay (service node)" : "client");
 
-#ifndef SROUTER_EMBEDDED_ONLY
-        if (is_service_node)
+        if (rpc_backend)
         {
-            log::debug(logcat, "Starting oxend RPC client");
-            _oxend = std::make_shared<rpc::OxendRPC>(*_omq, *this);
-        }
+            if (is_service_node)
+            {
+                log::debug(logcat, "Starting oxend RPC client");
+                _oxend = rpc_backend->make_oxend(*this, *_omq);
+            }
 
-        if (_config.api.enable_rpc_server)
-        {
-            log::debug(logcat, "Starting RPC server");
-            //
-            _rpc_server = std::make_shared<rpc::RPCServer>(*_omq, *this);
-        }
+            if (_config.api.enable_rpc_server)
+            {
+                log::debug(logcat, "Starting RPC server");
+                _rpc_server = rpc_backend->make_rpc_server(*this, *_omq);
+            }
 
-        log::debug(logcat, "Starting OMQ server");
-        _omq->start();
+            log::debug(logcat, "Starting OMQ server");
+            rpc_backend->start_omq(*_omq);
 
-        if (is_service_node)
-        {
-            log::debug(logcat, "Connecting to oxend @ {}", _config.oxend.rpc_addr);
-            _oxend->connect_async(oxenmq::address(_config.oxend.rpc_addr));
+            if (is_service_node)
+            {
+                log::debug(logcat, "Connecting to oxend @ {}", _config.oxend.rpc_addr);
+                _oxend->connect_async(_config.oxend.rpc_addr);
+            }
         }
-#endif
 
         log::debug(logcat, "Initializing key manager");
 
@@ -511,7 +494,6 @@ namespace srouter
 
         _node_db = std::make_unique<NodeDB>(*this);
 
-#ifndef SROUTER_EMBEDDED_ONLY
         if (is_service_node)
         {
             // Wait, synchronously, for the oxend SN list update, for up to 10s.  If we still don't
@@ -539,7 +521,6 @@ namespace srouter
             if (fallback)
                 _node_db->load_registered_relays_fallback();
         }
-#endif
 
         _session_endpoint = std::make_unique<handlers::SessionEndpoint>(*this);
 
@@ -999,10 +980,8 @@ namespace srouter
 
     void Router::on_test_ping()
     {
-#ifndef SROUTER_EMBEDDED_ONLY
         if (_router_testing)
             _router_testing->incoming_ping();
-#endif
     }
 
     void Router::stop()
@@ -1028,10 +1007,8 @@ namespace srouter
                 srouter::sys::service_manager->stopping();
             }
 
-#ifndef SROUTER_EMBEDDED_ONLY
             if (_router_testing)
                 _router_testing->stop();
-#endif
 
             _session_endpoint->stop(true);
 

--- a/src/router/router.hpp
+++ b/src/router/router.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config/definition.hpp"
+#include "consensus/reachability.hpp"
 #include "contact/relay_contact.hpp"
 #include "crypto/key_manager.hpp"
 #include "handlers/session.hpp"
@@ -9,6 +10,8 @@
 #include "path/path_context.hpp"
 #include "profiling.hpp"
 #include "route_poker.hpp"
+#include "router/rpc_backend.hpp"
+#include "rpc/oxend_client.hpp"
 #include "util/str.hpp"
 #include "util/time.hpp"
 #include "vpn/platform.hpp"
@@ -135,8 +138,9 @@ namespace srouter
         // connections.
         bool _has_established_paths{false};
 
-        // Not actually shared, but not available at all in non-full builds.
-        std::shared_ptr<consensus::reachability_testing> _router_testing;
+        // Held via the core IReachability interface; the concrete (relay-only) implementation is
+        // constructed by the full seam and is null in embedded/core-only builds.
+        std::shared_ptr<consensus::IReachability> _router_testing;
 
         // The actual network address we use for communications:
         quic::Address _listen_address;
@@ -192,7 +196,7 @@ namespace srouter
         // These aren't actually shared, but we unique_ptr requires destructor visibility, which
         // embedded-only clients won't have as they don't compile any RPC code.
         std::shared_ptr<rpc::RPCServer> _rpc_server;
-        std::shared_ptr<rpc::OxendRPC> _oxend;
+        std::shared_ptr<rpc::IOxendClient> _oxend;
 
         Profiling _router_profiling;
 
@@ -285,10 +289,7 @@ namespace srouter
 
         bool embedded() const { return _config.type == config::Type::EmbeddedClient; }
 
-        oxenmq::OxenMQ* omq() { return _omq.get(); }
-        const oxenmq::OxenMQ* omq() const { return _omq.get(); }
-
-        rpc::OxendRPC* oxend() const { return _oxend.get(); }
+        rpc::IOxendClient* oxend() const { return _oxend.get(); }
 
         const Ed25519SecretKey& secret_key() const { return key_manager.secret_key; }
         const RouterID& id() const { return key_manager.router_id(); }

--- a/src/router/router.hpp
+++ b/src/router/router.hpp
@@ -156,7 +156,7 @@ namespace srouter
         link::Endpoint* _link_endpoint = nullptr;
 
         // These are only created in full platform mode (not embedded clients)
-        std::shared_ptr<handlers::TunEndpoint> _tun;
+        std::shared_ptr<handlers::ITunnel> _tun;
         std::shared_ptr<dns::Listener> _dns;
         std::shared_ptr<vpn::Platform> _vpn;
         std::shared_ptr<RoutePoker> _route_poker;
@@ -229,7 +229,7 @@ namespace srouter
 
         bool is_fully_meshed() const;
 
-        const std::shared_ptr<handlers::TunEndpoint>& tun_endpoint() { return _tun; }
+        const std::shared_ptr<handlers::ITunnel>& tun_endpoint() { return _tun; }
 
         // Looks up the given IP in our TUN mapping and, if it is a TUN address and maps to a remote, returns the
         // network address of the mapped-to address.  The `.second` part of the result indicates

--- a/src/router/rpc_backend.hpp
+++ b/src/router/rpc_backend.hpp
@@ -19,6 +19,14 @@ namespace srouter
     {
         struct IReachability;
     }
+    namespace handlers
+    {
+        struct ITunnel;
+    }
+    namespace dns
+    {
+        class Listener;
+    }
 
     // Construction hooks for the full rpc/oxend/omq/reachability subsystem.  Installed once by
     // srouter::full::initialize() in full builds; left null in embedded/core-only builds (Router then
@@ -34,6 +42,8 @@ namespace srouter
         std::shared_ptr<rpc::IOxendClient> (*make_oxend)(Router&, oxenmq::OxenMQ&);
         std::shared_ptr<rpc::RPCServer> (*make_rpc_server)(Router&, oxenmq::OxenMQ&);
         std::shared_ptr<consensus::IReachability> (*make_reachability)(Router&);
+        std::shared_ptr<handlers::ITunnel> (*make_tun)(Router&);
+        std::shared_ptr<dns::Listener> (*make_dns)(Router&);
     };
 
     inline const RpcBackendHooks* rpc_backend = nullptr;

--- a/src/router/rpc_backend.hpp
+++ b/src/router/rpc_backend.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+
+namespace oxenmq
+{
+    class OxenMQ;
+}
+
+namespace srouter
+{
+    class Router;
+    namespace rpc
+    {
+        struct IOxendClient;
+        class RPCServer;
+    }  // namespace rpc
+    namespace consensus
+    {
+        struct IReachability;
+    }
+
+    // Construction hooks for the full rpc/oxend/omq/reachability subsystem.  Installed once by
+    // srouter::full::initialize() in full builds; left null in embedded/core-only builds (Router then
+    // leaves the corresponding members null and never runs the relay/rpc code paths).
+    //
+    // Router continues to own and drive the constructed objects -- these hooks only build them, which
+    // is what keeps oxenmq/rpc/reachability construction (and hence those dependencies) out of the
+    // core library.
+    struct RpcBackendHooks
+    {
+        std::shared_ptr<oxenmq::OxenMQ> (*make_omq)();
+        void (*start_omq)(oxenmq::OxenMQ&);
+        std::shared_ptr<rpc::IOxendClient> (*make_oxend)(Router&, oxenmq::OxenMQ&);
+        std::shared_ptr<rpc::RPCServer> (*make_rpc_server)(Router&, oxenmq::OxenMQ&);
+        std::shared_ptr<consensus::IReachability> (*make_reachability)(Router&);
+    };
+
+    inline const RpcBackendHooks* rpc_backend = nullptr;
+
+}  // namespace srouter

--- a/src/rpc/config_validation.cpp
+++ b/src/rpc/config_validation.cpp
@@ -1,0 +1,14 @@
+#include "config/config.hpp"
+
+#include <oxenmq/address.h>
+
+namespace srouter::config
+{
+    // Strict validation of the [oxend]:rpc address: constructing an oxenmq::address throws if the
+    // value is malformed.  This lives in the full (rpc) library so that oxenmq is not a dependency of
+    // the core config library; core falls back to a cheap scheme check (see config.cpp).
+    static void validate_oxend_rpc_addr_full(const std::string& arg) { oxenmq::address{arg}; }
+
+    void install_full_config_validators() { oxend_rpc_addr_validator = &validate_oxend_rpc_addr_full; }
+
+}  // namespace srouter::config

--- a/src/rpc/oxend_client.hpp
+++ b/src/rpc/oxend_client.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "contact/router_id.hpp"
+#include "contact/sns.hpp"
+#include "crypto/keys.hpp"
+
+#include <functional>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace srouter::rpc
+{
+    // Core-side interface for the oxend RPC client.  Router holds and drives an IOxendClient; the
+    // concrete implementation (OxendRPC, which needs oxenmq) lives in the full rpc library and is
+    // constructed via the full-only seam.  In embedded/core-only builds Router never constructs one
+    // (the pointer stays null), so core references only this interface -- never oxenmq.
+    struct IOxendClient
+    {
+        virtual ~IOxendClient() = default;
+
+        virtual void start_pings() = 0;
+
+        virtual Ed25519SecretKey obtain_identity_key() = 0;
+
+        // Connect to oxend asynchronously.  Takes the address as a string (parsed into an
+        // oxenmq::address by the implementation) so that oxenmq stays out of the core interface.
+        virtual void connect_async(std::string url) = 0;
+
+        virtual void update_service_node_list(std::shared_ptr<std::promise<void>> on_update = nullptr) = 0;
+
+        virtual void inform_connection(RouterID router, bool success) = 0;
+
+        virtual void lookup_sns_hash(
+            std::string_view namehash,
+            std::function<void(std::optional<std::pair<std::string, SymmNonce>>)> resultHandler) = 0;
+    };
+
+}  // namespace srouter::rpc

--- a/src/rpc/oxend_rpc.cpp
+++ b/src/rpc/oxend_rpc.cpp
@@ -24,19 +24,20 @@ namespace srouter::rpc
         _is_updating_list = false;
     }
 
-    void OxendRPC::connect_async(oxenmq::address url)
+    void OxendRPC::connect_async(std::string url)
     {
         if (not _router.is_service_node)
         {
             throw std::runtime_error("we cannot talk to oxend while not a service node");
         }
 
-        log::info(logcat, "RPC client connecting to oxend at {}", url.full_address());
+        oxenmq::address addr{url};
+        log::info(logcat, "RPC client connecting to oxend at {}", addr.full_address());
 
         _conn = _omq.connect_remote(
-            url,
+            addr,
             [](oxenmq::ConnectionID) {},
-            [this, url](oxenmq::ConnectionID, std::string_view f) {
+            [this, url = std::move(url)](oxenmq::ConnectionID, std::string_view f) {
                 log::info(logcat, "Failed to connect to oxend at {}", f);
                 _router._jq->call([this, url]() { connect_async(url); });
             });

--- a/src/rpc/oxend_rpc.hpp
+++ b/src/rpc/oxend_rpc.hpp
@@ -2,6 +2,7 @@
 
 #include "contact/router_id.hpp"
 #include "contact/sns.hpp"
+#include "rpc/oxend_client.hpp"
 #include "util/logging.hpp"
 
 #include <oxenmq/address.h>
@@ -22,34 +23,34 @@ namespace srouter::rpc
 
     /// OxenMQ RPC client for a relay to talk to its oxend to obtain info about and report on
     /// the service node network.
-    class OxendRPC
+    class OxendRPC : public IOxendClient
     {
       public:
         OxendRPC(oxenmq::OxenMQ& omq, Router& r);
 
         /// Connect to oxend async
-        void connect_async(oxenmq::address url);
+        void connect_async(std::string url) override;
 
         /// blocking request identity secret key from oxend
         /// throws on failure
-        Ed25519SecretKey obtain_identity_key();
+        Ed25519SecretKey obtain_identity_key() override;
 
         /// get what the current block height is according to oxend
         uint64_t block_height() const { return _block_height; }
 
         void lookup_sns_hash(
             std::string_view namehash,
-            std::function<void(std::optional<std::pair<std::string, SymmNonce>>)> resultHandler);
+            std::function<void(std::optional<std::pair<std::string, SymmNonce>>)> resultHandler) override;
 
         /// inform that if connected to a router successfully
-        void inform_connection(RouterID router, bool success);
+        void inform_connection(RouterID router, bool success) override;
 
-        void start_pings();
+        void start_pings() override;
 
         /// triggers a service node list refresh from oxend; thread-safe and will do nothing if
         /// an update is already in progress.  The promise is for router.cpp to attempt a
         /// synchronous update on startup, and should not be used otherwise.
-        void update_service_node_list(std::shared_ptr<std::promise<void>> on_update = nullptr);
+        void update_service_node_list(std::shared_ptr<std::promise<void>> on_update = nullptr) override;
 
       private:
         void ping();

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -830,7 +830,6 @@ namespace srouter::session
             return;
         }
 
-#ifndef SROUTER_EMBEDDED_ONLY
         // Otherwise we're not embedded; if the other side also isn't then this is just a raw IP
         // packet to handle via the tun endpoint, and the same for UDP packets from embedded
         // remotes (which also send raw UDP packets):
@@ -859,9 +858,8 @@ namespace srouter::session
             ipv4_mapped = true;
         }
 
-        assert(_r.tun_endpoint());  // (We return above if embedded)
-        _r.tun_endpoint()->handle_inbound_packet(std::move(pkt), dgram_type, _remote);
-#endif
+        if (auto& tun = _r.tun_endpoint())
+            tun->handle_inbound_packet(std::move(pkt), dgram_type, _remote);
     }
 
     void Session::publish_client_contact(std::string_view encrypted_cc)

--- a/src/util/nop_service_manager.cpp
+++ b/src/util/nop_service_manager.cpp
@@ -2,6 +2,8 @@
 
 namespace srouter::sys
 {
-    NOP_SystemLayerHandler _manager{};
-    I_SystemLayerManager* const service_manager = &_manager;
+    // This platform has no native service manager, so installing leaves the core default (no-op)
+    // handler in place.
+    void install_native_service_manager() {}
+
 }  // namespace srouter::sys

--- a/src/util/service_manager.cpp
+++ b/src/util/service_manager.cpp
@@ -1,0 +1,12 @@
+#include "service_manager.hpp"
+
+namespace srouter::sys
+{
+    // The default system-layer manager: a no-op handler that is always available in the core
+    // library.  This is what embedded usage gets (it never calls install_native_service_manager()),
+    // and the fallback for platforms with no native manager.  Full builds override this pointer via
+    // install_native_service_manager().
+    static NOP_SystemLayerHandler _nop_manager{};
+    I_SystemLayerManager* service_manager = &_nop_manager;
+
+}  // namespace srouter::sys

--- a/src/util/service_manager.hpp
+++ b/src/util/service_manager.hpp
@@ -86,7 +86,16 @@ namespace srouter::sys
         }
     };
 
-    extern I_SystemLayerManager* const service_manager;
+    // Global system-layer manager.  Defaults to a no-op handler (used for embedded usage and for
+    // platforms without a native service manager); full builds install a native implementation via
+    // install_native_service_manager().
+    extern I_SystemLayerManager* service_manager;
+
+    // Installs the platform's native service manager into the `service_manager` global, replacing the
+    // default no-op handler.  Provided by the full platform library (a no-op on platforms without a
+    // native service manager).  Must be called before the service manager is first used, i.e. by the
+    // daemon before it constructs the Context.
+    void install_native_service_manager();
 
     class NOP_SystemLayerHandler : public I_SystemLayerManager
     {

--- a/src/vpn/platform.hpp
+++ b/src/vpn/platform.hpp
@@ -120,4 +120,8 @@ namespace srouter::vpn
     /// create native vpn platform
     std::shared_ptr<Platform> MakeNativePlatform(srouter::Context* ctx);
 
+    // Settable factory for the platform's native vpn::Platform, installed by the full library
+    // (srouter::full::initialize) to &MakeNativePlatform.  Null in embedded/core-only builds.
+    inline std::shared_ptr<Platform> (*make_native_platform)(srouter::Context* ctx) = nullptr;
+
 }  // namespace srouter::vpn

--- a/src/win32/service_manager.cpp
+++ b/src/win32/service_manager.cpp
@@ -98,5 +98,6 @@ namespace srouter::sys
     }
 
     SVC_Manager _manager{};
-    I_SystemLayerManager* const service_manager = &_manager;
+
+    void install_native_service_manager() { service_manager = &_manager; }
 }  // namespace srouter::sys


### PR DESCRIPTION
This PR restructures session-router so it builds as two layered libraries instead of one.  The primary purpose is to solve a dependency ugliness:

- `-DSROUTER_FULL=OFF` would build a library suitable for embedded usage, with some codepaths disabled at compilation time, and omitting various things like libunbound and liboxen-mq (which are only needed for full clients and relays).
- `-DSROUTER_FULL=ON` (the default) would build a library that included everything, including libunbound-dev.  While this library was perfectly usable for both embedded and full, it meant that you always had to bring along libunbound and liboxenmq (and transitives) as package dependencies, which is a little bit annoying if you only care about embedded mode.

Thus this PR splits the library into two, and removes all the compile-time differences in the build:
- libsessionrouter-core contains all the core functionality common to embedded + full usage, but deliberately does not depend on code and external dependencies that are only needed in full client or relay mode, such as libunbound or oxen-mq.
- libsessionrouter is the "everything" library - it links to libsessionrouter-core, plus includes the extras needed for a full client (including linking to unbound and oxen-mq).  This includes things irrelevant to embedded usage such as oxend rpc, reachability testing, TUN endpoint, platform code.

This required some internal abstraction and mild reworking of the code to be able to cleanly sever the two components, but now builds and works successfully.