### PR TITLE
Small DNS-related fixes

### DIFF
--- a/src/dns/handler.cpp
+++ b/src/dns/handler.cpp
@@ -278,7 +278,7 @@ namespace srouter::dns
                         auto target = maybe_netaddr->to_string();
                         msg.add_cname_reply(target, std::chrono::floor<std::chrono::seconds>(ttl));
                         if (cname_only)
-                            return;
+                            return reply(msg.encode(tcp));
                         auto qname = sub.empty() ? target : "{}.{}"_format(fmt::join(sub, "."), target);
                         msg.set_rr_name(qname);
                         if (!handle_local(reply, msg, std::move(qname), tcp))

--- a/src/dns/handler.cpp
+++ b/src/dns/handler.cpp
@@ -452,9 +452,18 @@ namespace srouter::dns
                         const std::optional<ClientContact>& cc) mutable {
                         if (cc)
                         {
+                            bool found = false;
                             for (const auto& srv : cc->SRVs())
                                 if (srv.service == sub[0] && srv.proto == sub[1])
+                                {
                                     msg->add_reply(srv);
+                                    found = true;
+                                }
+
+                            // The contact exists, it just doesn't offer the requested
+                            // service/proto, which is a NODATA reply rather than a name failure.
+                            if (!found)
+                                msg->add_nodata_reply();
                         }
                         else
                             // Re-trying the request could initiate a new lookup, so *don't* put an

--- a/src/dns/handler.cpp
+++ b/src/dns/handler.cpp
@@ -399,18 +399,28 @@ namespace srouter::dns
                         if (auto v4_addr = tun.map4(*maybe_netaddr); v4_addr)
                             msg.add_reply(*v4_addr);
                         else
+                        {
+                            // We ran out of local IPv4s, which is a local failure rather than
+                            // anything to do with the name, and could succeed later:
                             log::warning(logcat, "IPv4 mapping requested for {} failed.", *maybe_netaddr);
+                            msg.servfail();
+                        }
                     }
-                    // else they requested A *not* using the magic ipv4 subdomain, so we only have
-                    // AAAA to offer and thus we return a reply without an answer record (which is
-                    // the proper DNS way to say "something exists at this address, but not with the
-                    // type you requested requested", as opposed to this nx_reply below, which means
-                    // "this record does not exist").
-                    //
-                    // In order for this NODATA result to be properly cacheable, we need an SOA
-                    // record included.  It'll also never work in the future, so we can use a
-                    // relatively longer negative TTL via the SOA.
-                    add_nx_soa(msg, tld, 5min);
+                    else
+                    {
+                        // They requested A *not* using the magic ipv4 subdomain, so we only have
+                        // AAAA to offer and thus we return a reply without an answer record (which
+                        // is the proper DNS way to say "something exists at this address, but not
+                        // with the type you requested", as opposed to the nxdomain below, which
+                        // means "this record does not exist" and would stop a client from going on
+                        // to ask for the AAAA that we *can* answer).
+                        //
+                        // In order for this NODATA result to be properly cacheable, we need an SOA
+                        // record included.  It'll also never work in the future, so we can use a
+                        // relatively longer negative TTL via the SOA.
+                        msg.add_nodata_reply();
+                        add_nx_soa(msg, tld, 5min);
+                    }
                 }
                 else
                 {
@@ -426,7 +436,8 @@ namespace srouter::dns
             }
 
             log::warning(logcat, "DNS query failure: '{}' is not a valid Session Router name or address", qname);
-            reply(msg.encode(tcp));
+            add_nx_soa(msg, tld, 30s);
+            reply(msg.nxdomain().encode(tcp));
             return true;
         }
 

--- a/src/dns/message.cpp
+++ b/src/dns/message.cpp
@@ -178,6 +178,7 @@ namespace srouter::dns
         {
             log::warning(logcat, "Ignoring archaic DNS request with {} > 1 questions", qd_count);
             m.bad_extract = true;
+            m.formerr();
             return result;
         }
         // Ignore these:
@@ -304,6 +305,7 @@ namespace srouter::dns
         {
             log::debug(logcat, "failed to parse DNS message: {}", e.what());
             m.bad_extract = true;
+            m.formerr();
         }
 
         return result;

--- a/src/dns/message.cpp
+++ b/src/dns/message.cpp
@@ -43,10 +43,16 @@ namespace srouter::dns
         std::span<std::byte> buf{tmp};
         uint16_t buf_offset = 0;
 
+        // A Message is only ever encoded as a response (upstream forwarding goes through unbound
+        // and RawMessage), so QR always belongs here regardless of what the individual reply path
+        // set up.  AD, on the other hand, has to be cleared: we copy the header fields from the
+        // request, but we do no DNSSEC validation and so must not claim the data is authenticated.
+        uint16_t fields = (hdr_fields | flags_QR) & ~flags_AD;
+
         buf_offset += write_ints_into(
             buf,
             hdr_id,
-            hdr_fields,
+            fields,
             question ? uint16_t{1} : uint16_t{0},
             static_cast<uint16_t>(answers.size()),
             static_cast<uint16_t>(authorities.size()),
@@ -76,7 +82,7 @@ namespace srouter::dns
         {
             log::debug(logcat, "Response too large!  Setting truncation bit");
 
-            oxenc::write_host_as_big(hdr_fields | flags_TC, tmp.data() + 2);
+            oxenc::write_host_as_big(fields | flags_TC, tmp.data() + 2);
 
             // Reset our buffer position back to just after the questions were added.  We do this
             // even if we aren't going to add EDNS stuff below, because we are not supposed to

--- a/src/handlers/tun.cpp
+++ b/src/handlers/tun.cpp
@@ -227,14 +227,17 @@ namespace srouter::handlers
         }
 
         assert(_local_ipv6_net.contains(*to_try));
-        if (!_local_ipv6_mapping.contains(*to_try) && *to_try != _local_ipv6_net.ip)
+        // A pubkey with a zero prefix maps onto the base address of the range, which is the
+        // subnet-router anycast address and so must never be handed out as a host address.
+        if (!_local_ipv6_mapping.contains(*to_try) && *to_try != _local_ipv6_net.ip
+            && *to_try != _local_ipv6_net.ip.to_base(_local_ipv6_net.mask))
         {
             log::debug(logcat, "Assigning pubkey-based local IPv6 {} for remote {}", *to_try, a);
             return to_try;
         }
         log::debug(
             logcat,
-            "Pubkey-based local IPv6 {} is already mapped; falling back to sequential IPv6 allocation",
+            "Pubkey-based local IPv6 {} for remote {} is unavailable; falling back to sequential IPv6 allocation",
             *to_try,
             a);
 


### PR DESCRIPTION
- When looking up a dummy address that starts with lots of 0s (e.g. the all-0 address, `yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy.sesh`) the IPv6 address assigner would hand out the IPv6 subnet's 0 address, but that is very wrong.  Fixed by explicitly detecting that and handing out a sequential address instead.
- A handful of DNS requests were not properly setting the QR bit on a response.  DNS clients *probably* ignore that, but it should be set correctly anyway.
- Explicitly clear the AD bit from responses instead of copying it back possibly set.
- Fix some minor issues around AAAA/A responses, mostly around flags not being set quite right.
- unparseable DNS requests should be receiving a FORMERR response, and weren't.
- SRV requests for records that don't exist didn't have proper response flags set.
- CNAME queries lookups (i.e. direct CNAME lookups, not automatic CNAME lookups such as looking up ONS) were not returning a response at all.