### PR TITLE
Fast fail unreachable relay

### DIFF
--- a/contrib/libsession-router_jank_test.cpp
+++ b/contrib/libsession-router_jank_test.cpp
@@ -44,6 +44,9 @@ int main(int argc, char** argv)
     std::promise<void> prom;
     std::promise<void> conn_prom;
 
+    // Holding this is what keeps the tunnel up; dropping it releases it.
+    session::router::udp_tunnel tunnel;
+
     bool first_conn = true;
     srouter->on_connected([&] {
         if (!first_conn)
@@ -88,7 +91,7 @@ int main(int argc, char** argv)
 
         target = resolve_prom.get_future().get();
 
-        srouter->establish_udp(
+        tunnel = srouter->establish_udp(
             target,
             port,
             [&prom, &start, &port](auto udp_info) {
@@ -99,10 +102,12 @@ int main(int argc, char** argv)
                     << std::flush;
                 prom.set_value();
             },
-            [&prom]() {
+            [&prom](auto failure) {
                 try
                 {
-                    throw std::runtime_error{"Session timed out!"};
+                    throw std::runtime_error{
+                        failure == session::router::tunnel_failure::unreachable ? "Remote is unreachable!"
+                                                                               : "Session timed out!"};
                 }
                 catch (...)
                 {
@@ -158,13 +163,14 @@ int main(int argc, char** argv)
             {
                 case SIGHUP:
                     std::cout << "\n\n\n\x1b[33;1mHangup signal received; closing UDP tunnel\x1b[0m\n\n\n";
-                    srouter->close_udp(target, port);
+                    tunnel.reset();
                     break;
                 case SIGUSR1:
                 {
                     std::cout << "\n\n\n\x1b[32;1mSIGUSR1 received: (re-)opening UDP tunnel\x1b[0m\n";
-                    if (auto ti = srouter->establish_udp(target, port))
-                        std::cout << "\n\x1b[32;1mUDP bound to port " << ti->local_port << "\x1b[0m\n\n";
+                    tunnel = srouter->establish_udp(target, port);
+                    if (tunnel)
+                        std::cout << "\n\x1b[32;1mUDP bound to port " << tunnel->local_port << "\x1b[0m\n\n";
                     else
                         std::cout << "\n\x1b[31;1m" << target << " is unreachable\x1b[0m\n\n";
                     break;

--- a/contrib/libsession-router_jank_test.cpp
+++ b/contrib/libsession-router_jank_test.cpp
@@ -163,8 +163,10 @@ int main(int argc, char** argv)
                 case SIGUSR1:
                 {
                     std::cout << "\n\n\n\x1b[32;1mSIGUSR1 received: (re-)opening UDP tunnel\x1b[0m\n";
-                    auto ti = srouter->establish_udp(target, port);
-                    std::cout << "\n\x1b[32;1mUDP bound to port " << ti.local_port << "\x1b[0m\n\n";
+                    if (auto ti = srouter->establish_udp(target, port))
+                        std::cout << "\n\x1b[32;1mUDP bound to port " << ti->local_port << "\x1b[0m\n\n";
+                    else
+                        std::cout << "\n\x1b[31;1m" << target << " is unreachable\x1b[0m\n\n";
                     break;
                 }
                 case SIGUSR2:

--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -125,9 +125,21 @@ namespace session::router
         //
         // (This method does not accept SNS names: you need to call resolve_sns() first for that).
         //
-        // The returned object contains the port information.  The tunnel will remain active until
-        // drop_udp() is called with the same remote address and port (or the SessionRouter instance
-        // is destroyed).  The caller should track this and drop UDP ports when no longer needed.
+        // Returns nullopt if the remote is a relay that we know we cannot reach: we hold relay
+        // contacts for every relay participating in the network, so a relay we have no contact for
+        // is one that is not participating (it may be running a version without Session Router, or
+        // be misconfigured).  No tunnel is established in that case and neither callback is
+        // invoked, so a caller choosing between several relays can move on to the next one
+        // immediately rather than waiting out a build timeout.
+        //
+        // Note that nullopt is a statement about this moment, not a permanent one, and it is only
+        // returned once relay contacts have actually been fetched: before the first fetch
+        // completes, the request is held until we know the answer.
+        //
+        // Otherwise the returned object contains the port information.  The tunnel will remain
+        // active until drop_udp() is called with the same remote address and port (or the
+        // SessionRouter instance is destroyed).  The caller should track this and drop UDP ports
+        // when no longer needed.
         //
         // Calling with an already-established remote/port simply returns that existing mapping, it
         // does *not* create a new one.
@@ -150,7 +162,7 @@ namespace session::router
         //
         // Take care not to use very slow or blocking code inside the callbacks: they are called
         // from Session Router's logic thread (and so any blocking will stall Session Router).
-        tunnel_info establish_udp(
+        std::optional<tunnel_info> establish_udp(
             std::string_view remote,
             uint16_t port,
             std::function<void(tunnel_info)> on_established = nullptr,

--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -188,42 +188,49 @@ namespace session::router
         //
         // (This method does not accept SNS names: you need to call resolve_sns() first for that).
         //
-        // Returns an empty udp_tunnel if the remote is a relay that we know we cannot reach: we hold
-        // relay contacts for every relay participating in the network, so a relay we have no contact
-        // for is one that is not participating (it may be running a version without Session Router,
-        // or be misconfigured).  No tunnel is established in that case and neither callback is
-        // invoked, so a caller choosing between several relays can move on to the next one
-        // immediately rather than waiting out a build timeout.
+        // Exactly one of three things happens:
         //
-        // Note that an empty return is a statement about this moment, not a permanent one, and it
-        // only happens once relay contacts have actually been fetched: before the first fetch
-        // completes, the request is held until we know the answer.
+        // 1. It throws, if `remote` is unparseable, is an SNS name, or `port` is 0.  Nothing is
+        //    mapped and no callback is ever invoked.
         //
-        // Otherwise the returned udp_tunnel is a claim on the mapping and carries its port
-        // information.  The tunnel stays up until every claim on it has been destroyed (or the
-        // SessionRouter is), so the caller need only hold this object for as long as it wants the
-        // tunnel; there is nothing else to remember to call.
+        // 2. It returns an empty claim, if `remote` is a relay the network holds no relay contact
+        //    for.  We hold contacts for every relay participating in the network, so a relay
+        //    without one is not participating (it may be running a version without Session Router,
+        //    or be misconfigured).  Nothing is mapped and no callback is ever invoked, so a caller
+        //    choosing between several relays can move on to the next immediately rather than
+        //    waiting out a build timeout.
         //
-        // Asking for an already-mapped remote/port returns another claim on that same mapping, it
-        // does *not* create a new one.
+        //    This is a statement about right now rather than a permanent one, and it only happens
+        //    once relay contacts have actually been fetched: before the first fetch completes the
+        //    request is held until we know the answer, so this never guesses.
         //
-        // This method will throw if the given address is unparseable.
+        // 3. It returns a claim on the mapping, carrying its port information, and exactly one of
+        //    the two callbacks is subsequently invoked (whichever of them was provided):
         //
-        // If an `on_established` callback is provided then it will be called once the full session
-        // is established, and passed the same tunnel_info data carried by the returned claim.  Note
-        // that `on_established` can be called immediately (i.e. before `establish_udp()` returns),
-        // if a session to the remote is already established.
+        //    - `on_established(info)`, once the session is up, with the same tunnel_info the claim
+        //      carries.  This one *can* fire before establish_udp returns, if a session to the
+        //      remote already exists, so be ready for it to run during the call.
         //
-        // `on_failed` is invoked instead of `on_established` if the session fails to establish, and
-        // is told which of the two happened.  In particular a relay whose relay contact we did not
-        // have yet, and which turns out on lookup not to have one, is reported as `unreachable`
-        // here rather than as a timeout: the empty return above can only cover the case where we
-        // already knew before returning.  Note that:
-        // - `on_failed` is *not* called if the call throws (such as if given an unparseable
-        //   address), nor if the return is empty (in which case there is no tunnel to report on).
-        // - an `on_failed` call does *not* mean the tunnel has been released: it remains mapped for
-        //   as long as the claim is held, and future attempts to connect to the tunnel port will
-        //   attempt to (re-)establish the session.  Drop the claim if you want it gone.
+        //    - `on_failed(unreachable)`, if the relay turned out to have no relay contact after
+        //      all.  This is case 2 discovered late: we had not yet fetched contacts when asked, so
+        //      the mapping was made before the answer came back.  Unlike case 2, a mapping does
+        //      exist and the claim is real.
+        //
+        //    - `on_failed(timeout)`, if the session did not come up in time.  Unlike the above, the
+        //      remote may well be reachable and worth another attempt shortly.
+        //
+        //    `on_failed` is never invoked before establish_udp returns.  Neither callback fires if
+        //    the SessionRouter is destroyed while the session is still coming up.
+        //
+        // A failure does not release the tunnel: it stays mapped for as long as a claim is held,
+        // and sending to the tunnel port again will attempt to re-establish the session.  Drop the
+        // claim if you want it gone.
+        //
+        // The tunnel stays up until every claim on it has been destroyed (or the SessionRouter is),
+        // so a caller need only hold its claim for as long as it wants the tunnel; there is nothing
+        // to remember to call.  Asking for an already-mapped remote/port returns another claim on
+        // that same mapping rather than creating a new one, so releasing a claim can never take the
+        // tunnel away from another holder.
         //
         // Take care not to use very slow or blocking code inside the callbacks: they are called
         // from Session Router's logic thread (and so any blocking will stall Session Router).

--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -27,8 +27,8 @@ namespace session::router
         TESTNET
     };
 
-    /// Object returned when establishing a session for a TCP or UDP tunnel.  The tunnel port will
-    /// be kept open until close_udp()/close_tcp() is called with the same remote and port.
+    /// The details of an established TCP or UDP tunnel.  This is plain data describing the tunnel;
+    /// what keeps a UDP tunnel open is holding the udp_tunnel claim that carries it.
     struct tunnel_info
     {
         /// The requested remote address.  If an ONS entry was requested, this will be the resolved
@@ -58,11 +58,74 @@ namespace session::router
         std::optional<uint16_t> suggested_mtu;
     };
 
+    /// Why a tunnel that was requested did not come up.
+    enum class tunnel_failure
+    {
+        /// The session did not establish in time.  The remote may well be reachable; this attempt
+        /// did not get there.
+        timeout,
+
+        /// The remote is a relay for which the network holds no relay contact, and so cannot be
+        /// reached at all until it rejoins.  Attempting it again immediately is pointless, but the
+        /// verdict is not permanent: it is re-checked on each attempt.
+        unreachable,
+    };
+
+    class SessionRouter;
+
+    /// A claim on a Session Router UDP tunnel, obtained from SessionRouter::establish_udp().
+    ///
+    /// Asking for a remote address and port that is already mapped hands back the same mapping
+    /// rather than making a new one, so a mapping can have several claims on it at once.  It stays
+    /// up until the last of them is destroyed, which means a caller only has to keep its own claim
+    /// for as long as it wants the tunnel: releasing it can never pull the tunnel out from under
+    /// someone else.
+    ///
+    /// An empty claim (default-constructed, moved-from, or reset) refers to no tunnel and releases
+    /// nothing; test with `operator bool`.  The tunnel's details are reached through `*` and `->`.
+    ///
+    /// Destroying the SessionRouter releases every tunnel with it, so a claim outliving its router
+    /// is harmless.
+    class udp_tunnel
+    {
+        friend class SessionRouter;
+
+        std::weak_ptr<void> _router_alive;
+        SessionRouter* _router{nullptr};
+        tunnel_info _info;
+
+        udp_tunnel(SessionRouter& router, std::weak_ptr<void> alive, tunnel_info info);
+
+      public:
+        udp_tunnel() = default;
+        udp_tunnel(udp_tunnel&& other) noexcept { *this = std::move(other); }
+        udp_tunnel& operator=(udp_tunnel&& other) noexcept;
+        udp_tunnel(const udp_tunnel&) = delete;
+        udp_tunnel& operator=(const udp_tunnel&) = delete;
+        ~udp_tunnel();
+
+        /// Releases this claim now rather than at destruction, leaving the object empty.
+        void reset();
+
+        explicit operator bool() const { return _router != nullptr; }
+
+        const tunnel_info& operator*() const { return _info; }
+        const tunnel_info* operator->() const { return &_info; }
+    };
+
     using snode_path = std::vector<std::pair<std::string, std::string>>;
     using session_path = std::pair<snode_path, std::string>;
 
     class SessionRouter
     {
+        friend class udp_tunnel;
+
+        // Lets a udp_tunnel that outlives us know not to touch us on the way out.
+        std::shared_ptr<void> _alive{std::make_shared<char>()};
+
+        // Releases one claim on a UDP tunnel; the mapping goes away with the last one.
+        void release_udp(const std::string& remote, uint16_t port);
+
         std::unique_ptr<srouter::Context> context;
 
         struct path_ctor
@@ -125,52 +188,50 @@ namespace session::router
         //
         // (This method does not accept SNS names: you need to call resolve_sns() first for that).
         //
-        // Returns nullopt if the remote is a relay that we know we cannot reach: we hold relay
-        // contacts for every relay participating in the network, so a relay we have no contact for
-        // is one that is not participating (it may be running a version without Session Router, or
-        // be misconfigured).  No tunnel is established in that case and neither callback is
+        // Returns an empty udp_tunnel if the remote is a relay that we know we cannot reach: we hold
+        // relay contacts for every relay participating in the network, so a relay we have no contact
+        // for is one that is not participating (it may be running a version without Session Router,
+        // or be misconfigured).  No tunnel is established in that case and neither callback is
         // invoked, so a caller choosing between several relays can move on to the next one
         // immediately rather than waiting out a build timeout.
         //
-        // Note that nullopt is a statement about this moment, not a permanent one, and it is only
-        // returned once relay contacts have actually been fetched: before the first fetch
+        // Note that an empty return is a statement about this moment, not a permanent one, and it
+        // only happens once relay contacts have actually been fetched: before the first fetch
         // completes, the request is held until we know the answer.
         //
-        // Otherwise the returned object contains the port information.  The tunnel will remain
-        // active until drop_udp() is called with the same remote address and port (or the
-        // SessionRouter instance is destroyed).  The caller should track this and drop UDP ports
-        // when no longer needed.
+        // Otherwise the returned udp_tunnel is a claim on the mapping and carries its port
+        // information.  The tunnel stays up until every claim on it has been destroyed (or the
+        // SessionRouter is), so the caller need only hold this object for as long as it wants the
+        // tunnel; there is nothing else to remember to call.
         //
-        // Calling with an already-established remote/port simply returns that existing mapping, it
+        // Asking for an already-mapped remote/port returns another claim on that same mapping, it
         // does *not* create a new one.
         //
         // This method will throw if the given address is unparseable.
         //
         // If an `on_established` callback is provided then it will be called once the full session
-        // is established, and passed the same tunnel_info data that was returned by the initial
-        // call.  Note that `on_established` can be called immediately (i.e. before
-        // `establish_udp()` returns), if a session to the remote is already established.
+        // is established, and passed the same tunnel_info data carried by the returned claim.  Note
+        // that `on_established` can be called immediately (i.e. before `establish_udp()` returns),
+        // if a session to the remote is already established.
         //
-        // `on_timeout` is invoked instead of `on_established` if the session fails to establish.
-        // Note that:
-        // - `on_timeout` is *not* called if the call throws (such as if given an unparseable
-        //   address).
-        // - an `on_timeout` call does *not* mean the tunnel has been cancelled: it will remain
-        //   active and future attempts to connect to the tunnel port will attempt to (re-)establish
-        //   the session.  If you want to cancel it on session initiation failure, you must call
-        //   `close_udp()` from within the on_timeout callback.
+        // `on_failed` is invoked instead of `on_established` if the session fails to establish, and
+        // is told which of the two happened.  In particular a relay whose relay contact we did not
+        // have yet, and which turns out on lookup not to have one, is reported as `unreachable`
+        // here rather than as a timeout: the empty return above can only cover the case where we
+        // already knew before returning.  Note that:
+        // - `on_failed` is *not* called if the call throws (such as if given an unparseable
+        //   address), nor if the return is empty (in which case there is no tunnel to report on).
+        // - an `on_failed` call does *not* mean the tunnel has been released: it remains mapped for
+        //   as long as the claim is held, and future attempts to connect to the tunnel port will
+        //   attempt to (re-)establish the session.  Drop the claim if you want it gone.
         //
         // Take care not to use very slow or blocking code inside the callbacks: they are called
         // from Session Router's logic thread (and so any blocking will stall Session Router).
-        std::optional<tunnel_info> establish_udp(
+        udp_tunnel establish_udp(
             std::string_view remote,
             uint16_t port,
             std::function<void(tunnel_info)> on_established = nullptr,
-            std::function<void()> on_timeout = nullptr);
-
-        // Closes a tunnel socket to the given remote/port combination, releasing any internal
-        // mappings set up from previous connections through the tunnel.
-        void close_udp(std::string_view remote, uint16_t port);
+            std::function<void(tunnel_failure)> on_failed = nullptr);
 
         // Takes an ONS/SNS address such as "blocks.loki" and attempts to resolve it to a Session
         // Router client (aka hidden service) address such as

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1352,8 +1352,9 @@ namespace srouter::handlers
             }
 
             mapped_remote target{.remote = remote, .port = port};
-            auto& [udp_handle, cports] = _udp_handles[target];
+            auto& [udp_handle, cports, holders] = _udp_handles[target];
             bool existing = static_cast<bool>(udp_handle);
+            holders++;
             if (!existing)
 
                 udp_handle = std::make_unique<quic::UDPSocket>(
@@ -1414,7 +1415,7 @@ namespace srouter::handlers
                                 }
                             }
                             if (auto it = _udp_handles.find(target); it != _udp_handles.end())
-                                it->second.second.push_back(instance);
+                                it->second.cports.push_back(instance);
                             mapped_port = new_port.port;
                             log::debug(
                                 logcat,
@@ -1460,7 +1461,14 @@ namespace srouter::handlers
                 return;
             }
 
-            auto& [sock, cports] = it->second;
+            auto& [sock, cports, holders] = it->second;
+            if (--holders > 0)
+            {
+                log::debug(
+                    logcat, "Released a claim on {}:{}; {} still held, keeping it mapped", remote, port, holders);
+                return;
+            }
+
             for (auto& c : cports)
             {
                 if (auto cit = _udp_client_ports.find(c); cit != _udp_client_ports.end())

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1448,29 +1448,33 @@ namespace srouter::handlers
 
     void SessionEndpoint::unmap_udp_remote_port(const NetworkAddress& remote, uint16_t port)
     {
-        mapped_remote rem{.remote = remote, .port = port};
+        // As in map_udp_remote_port: these containers belong to the job queue thread, and an
+        // embedded caller can be on any thread at all.
+        router._jq->call_get([&] {
+            mapped_remote rem{.remote = remote, .port = port};
 
-        auto it = _udp_handles.find(rem);
-        if (it == _udp_handles.end())
-        {
-            log::debug(logcat, "Nothing to unmap: {}:{} is not currently a mapped UDP port", remote, port);
-            return;
-        }
-
-        auto& [sock, cports] = it->second;
-        for (auto& c : cports)
-        {
-            if (auto cit = _udp_client_ports.find(c); cit != _udp_client_ports.end())
+            auto it = _udp_handles.find(rem);
+            if (it == _udp_handles.end())
             {
-                _udp_return_ports.erase(mapped_remote{.remote = remote, .port = cit->second});
-                _udp_client_ports.erase(cit);
+                log::debug(logcat, "Nothing to unmap: {}:{} is not currently a mapped UDP port", remote, port);
+                return;
             }
-        }
 
-        auto local_port = sock->address().port();
-        _udp_handles.erase(it);
+            auto& [sock, cports] = it->second;
+            for (auto& c : cports)
+            {
+                if (auto cit = _udp_client_ports.find(c); cit != _udp_client_ports.end())
+                {
+                    _udp_return_ports.erase(mapped_remote{.remote = remote, .port = cit->second});
+                    _udp_client_ports.erase(cit);
+                }
+            }
 
-        log::debug(logcat, "Unmapped localhost:{} -> {}:{} UDP mapping", local_port, remote, port);
+            auto local_port = sock->address().port();
+            _udp_handles.erase(it);
+
+            log::debug(logcat, "Unmapped localhost:{} -> {}:{} UDP mapping", local_port, remote, port);
+        });
     }
 
 }  //  namespace srouter::handlers

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1268,7 +1268,7 @@ namespace srouter::handlers
             std::shared_ptr<session::Session> s{nullptr};
             if (auto it = _sessions.find(remote); it != _sessions.end())
                 s = it->second;
-            if (s && !s->is_closed())
+            if (s && !s->is_closed() && !s->is_unreachable())
             {
                 if (on_attempted)
                 {
@@ -1295,6 +1295,14 @@ namespace srouter::handlers
                     else
                         s = router._jq->make_shared<session::OutboundRelaySession>(
                             remote, *this, tag, std::move(on_attempted), timeout);
+
+                    // A relay session resolves its RC during construction, so if the relay has no
+                    // RC we already know the session can never establish.  Don't register it: the
+                    // caller gets nullptr, and a later attempt builds a fresh session that looks
+                    // the RC up again rather than reusing this verdict.
+                    if (s->is_unreachable())
+                        return std::shared_ptr<session::Session>{nullptr};
+
                     _session_tags.emplace(tag, s);
                     _sessions[remote] = s;
                 }
@@ -1323,10 +1331,10 @@ namespace srouter::handlers
             visit(addr, *s);
     }
 
-    std::pair<uint16_t, std::shared_ptr<session::Session>> SessionEndpoint::map_udp_remote_port(
+    std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> SessionEndpoint::map_udp_remote_port(
         const NetworkAddress& remote, uint16_t port)
     {
-        return router._jq->call_get([&] {
+        return router._jq->call_get([&]() -> std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> {
             // Port selection: we pick something random in the 49152-60000 range to start from, as
             // that range (up to 60999) is common to all modern OSes for ephemeral addresses, and so
             // at least our first thousand ports will look like a normal random ephemeral port.
@@ -1337,6 +1345,11 @@ namespace srouter::handlers
             std::pair<uint16_t, std::shared_ptr<session::Session>> result;
             auto& [local_port, session] = result;
             session = initiate_remote_session(remote);  // throws on immediate error
+            if (!session)
+            {
+                log::debug(logcat, "Not mapping a UDP port for {}: remote is unreachable", remote);
+                return std::nullopt;
+            }
 
             mapped_remote target{.remote = remote, .port = port};
             auto& [udp_handle, cports] = _udp_handles[target];
@@ -1364,6 +1377,14 @@ namespace srouter::handlers
                                 "Received local mapped UDP packet, but unable to obtain/initiate a session with {}: {}",
                                 target.remote,
                                 e.what());
+                            return;
+                        }
+                        if (!session)
+                        {
+                            log::warning(
+                                logcat,
+                                "Received local mapped UDP packet for unreachable remote {}, dropping",
+                                target.remote);
                             return;
                         }
 

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -310,8 +310,12 @@ namespace srouter
             // usage).
             //
             // This method throws *without* calling `on_attempted` if a Session cannot be attempted,
-            // such as when `remote` does not contain a valid pubkey.  If it does not throw, then it
-            // always returns a non-null shared_ptr.
+            // such as when `remote` does not contain a valid pubkey.
+            //
+            // Returns nullptr if the remote is known to be unreachable, i.e. it is a relay for
+            // which the network holds no relay contact.  `on_attempted`, if given, is still called
+            // (with a non-established session) before returning, so a caller that only watches the
+            // callback remains correct; the null return simply reports the same failure sooner.
             std::shared_ptr<session::Session> initiate_remote_session(
                 const NetworkAddress& remote,
                 std::function<void(session::Session& session)> on_attempted = nullptr,
@@ -337,9 +341,13 @@ namespace srouter
             //   desired).  Note that the session could change over time, e.g. if it is deleted by
             //   idle time out and then is re-established as a result of activity to this port.
             //
+            // Returns nullopt, without mapping a port, if the remote is known to be unreachable
+            // (see initiate_remote_session).  Mapping a port would be pointless in that case: no
+            // session can carry what gets sent to it.
+            //
             // Throws (via initiate_remote_session) if the Session could not be initiated, such as
             // when given an invalid pubkey in `remote`.
-            std::pair<uint16_t, std::shared_ptr<session::Session>> map_udp_remote_port(
+            std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> map_udp_remote_port(
                 const NetworkAddress& remote, uint16_t port);
 
             // Removes a mapping previously established with map_udp_remote_port; this closes the

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -128,15 +128,24 @@ namespace srouter
             std::unordered_map<mapped_remote, uint16_t, mapped_remote::hash> _udp_client_ports;
             std::unordered_map<mapped_remote, uint16_t, mapped_remote::hash> _udp_return_ports;
 
-            // Stores any established embedded client UDP maps: {remote:port} -> {socket,cports}, so
-            // that you can safely ask for the same remote:port again and just get the existing one
-            // rather than a new listening socket.  cports is a vector of keys of _udp_client_ports,
-            // used when deleting the handle.
-            std::unordered_map<
-                mapped_remote,
-                std::pair<std::unique_ptr<quic::UDPSocket>, std::vector<mapped_remote>>,
-                mapped_remote::hash>
-                _udp_handles;
+            struct udp_handle
+            {
+                std::unique_ptr<quic::UDPSocket> socket;
+
+                // Keys of _udp_client_ports belonging to this handle, used when deleting it.
+                std::vector<mapped_remote> cports;
+
+                // How many callers currently hold this mapping.  Asking for a remote:port that is
+                // already mapped hands back the same socket rather than a new one, so the mapping
+                // outlives any single holder: it is torn down when the last one unmaps it, not the
+                // first.
+                int holders = 0;
+            };
+
+            // Stores any established embedded client UDP maps: {remote:port} -> handle, so that you
+            // can safely ask for the same remote:port again and just get the existing one rather
+            // than a new listening socket.
+            std::unordered_map<mapped_remote, udp_handle, mapped_remote::hash> _udp_handles;
 
             uint16_t _next_udp_client_port{0};
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -915,7 +915,7 @@ namespace srouter::session
             log::debug(logcat, "Received udp datagram from unknown source port {}", *source_port);
             return;
         }
-        auto& socket = *it->second.first;
+        auto& socket = *it->second.socket;
 
         log::trace(logcat, "incoming udp packet for pseudo port {}", *dest_port);
         mapped_remote local{.remote = _remote, .port = *dest_port};

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1041,6 +1041,25 @@ namespace srouter::session
         }
     }
 
+    void OutboundSession::mark_unreachable()
+    {
+        _unreachable = true;
+        _dead_path = true;
+
+        while (!_on_established.empty())
+        {
+            try
+            {
+                _on_established.top().second(*this);
+            }
+            catch (const std::exception& e)
+            {
+                log::warning(logcat, "Exception during outbound session established callback: {}", e.what());
+            }
+            _on_established.pop();
+        }
+    }
+
     void OutboundSession::on_established(
         std::function<void(OutboundSession&)> callback, std::optional<std::chrono::milliseconds> timeout)
     {
@@ -1237,9 +1256,8 @@ namespace srouter::session
             }
             else
             {
-                log::debug(logcat, "RC lookup failed for {}", _remote);
-                // TODO FIXME: should we close the session?  Retry the lookup?  Start responding
-                // with ICMP unreachables?
+                log::debug(logcat, "RC lookup failed for {}; relay is unreachable", _remote);
+                mark_unreachable();
             }
         });
     }

--- a/src/session/session.hpp
+++ b/src/session/session.hpp
@@ -194,6 +194,13 @@ namespace srouter
             // will never become non-closed; reestablishing a closed Session requires replacing it).
             bool _is_closed{false};
 
+            // Will be set to true if we determine that this session can never be established,
+            // as opposed to merely not having established yet.  Currently this means the remote
+            // is a relay for which the network has no relay contact: we know how to reach any
+            // relay we hold an RC for, and we hold RCs for all of them, so a missing RC means the
+            // relay is not participating in the network at all.
+            bool _unreachable{false};
+
             // Set to true if our current path is definitely dead, to short-circuit things like
             // send_session_message encryption if we know we can't deliver it anywhere.  This
             // is roughly equivalent to `!path || path->is_dead`, except that the base class doesn't
@@ -338,6 +345,12 @@ namespace srouter
             // down.
             bool is_closed() const { return _is_closed; }
 
+            // Returns true if this session is known to be impossible to establish, rather than
+            // simply not established yet.  Such a session must not be reused: a later attempt on
+            // the same remote should build a fresh one, as the information that made this one
+            // unreachable (currently: a missing relay contact) can change.
+            bool is_unreachable() const { return _unreachable; }
+
             // Called to close this session.  If the bool is true then the session will attempt to
             // send a session_close control message down the active path.
             void close(bool send_close);
@@ -401,6 +414,12 @@ namespace srouter
                 std::vector<std::byte>&& data, SymmNonce&& nonce, path::MessageType type) override;
 
             void queue_data_message(std::span<const std::byte>, traffic_type type) override;
+
+            // Marks the session unreachable and fires every waiting on_established callback right
+            // away rather than letting each one sit until its own deadline.  For a session we know
+            // can never establish, the deadline would only be telling the caller something we
+            // already know.
+            void mark_unreachable();
 
             // We stash the `type` as the last byte of the vector
             std::optional<std::deque<std::vector<std::byte>>> pre_establish_data_queue;

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -65,11 +65,11 @@ namespace session::router
         context->router->on_disconnected(std::move(callback), with_path, persist);
     }
 
-    std::optional<tunnel_info> SessionRouter::establish_udp(
+    udp_tunnel SessionRouter::establish_udp(
         std::string_view remote,
         uint16_t dest_port,
         std::function<void(tunnel_info)> on_established,
-        std::function<void()> on_timeout)
+        std::function<void(tunnel_failure)> on_failed)
     {
         if (srouter::is_valid_sns(remote))
             throw std::invalid_argument{"establish_udp requires a network pubkey address, not an ONS/SNS addresses"};
@@ -94,7 +94,7 @@ namespace session::router
 
         auto mapped = context->router->session_endpoint().map_udp_remote_port(netaddr, dest_port);
         if (!mapped)
-            return std::nullopt;
+            return {};
 
         auto& [local_port, session] = *mapped;
 
@@ -123,22 +123,22 @@ namespace session::router
         }
         else if (session->is_outbound)
         {
-            if (on_established || on_timeout)
+            if (on_established || on_failed)
             {
                 auto osession = std::static_pointer_cast<srouter::session::OutboundSession>(session);
-                osession->on_established(
-                    [ti, on_established, on_timeout](const srouter::session::OutboundSession& session) {
-                        if (session.is_established())
-                        {
-                            if (on_established)
-                                on_established(ti);
-                        }
-                        else
-                        {
-                            if (on_timeout)
-                                on_timeout();
-                        }
-                    });
+                osession->on_established([ti, on_established, on_failed](
+                                             const srouter::session::OutboundSession& session) {
+                    if (session.is_established())
+                    {
+                        if (on_established)
+                            on_established(ti);
+                    }
+                    else
+                    {
+                        if (on_failed)
+                            on_failed(session.is_unreachable() ? tunnel_failure::unreachable : tunnel_failure::timeout);
+                    }
+                });
             }
         }
         else
@@ -147,22 +147,51 @@ namespace session::router
                 logcat, "Unexpected: tunnel session returned a non-established, but also non-outbound session!");
         }
 
-        return ti;
+        return udp_tunnel{*this, _alive, std::move(ti)};
     }
 
-    void SessionRouter::close_udp(std::string_view remote, uint16_t port)
+    udp_tunnel::udp_tunnel(SessionRouter& router, std::weak_ptr<void> alive, tunnel_info info)
+        : _router_alive{std::move(alive)}, _router{&router}, _info{std::move(info)}
+    {}
+
+    udp_tunnel& udp_tunnel::operator=(udp_tunnel&& other) noexcept
     {
-        srouter::NetworkAddress netaddr;
+        reset();
+        _router_alive = std::exchange(other._router_alive, {});
+        _router = std::exchange(other._router, nullptr);
+        _info = std::exchange(other._info, {});
+        return *this;
+    }
+
+    udp_tunnel::~udp_tunnel() { reset(); }
+
+    void udp_tunnel::reset()
+    {
+        if (!_router)
+            return;
+
+        // A claim can outlive the router it came from, in which case the mapping went away with it.
+        if (auto alive = _router_alive.lock())
+            _router->release_udp(_info.remote, _info.remote_port);
+
+        _router_alive.reset();
+        _router = nullptr;
+        _info = {};
+    }
+
+    void SessionRouter::release_udp(const std::string& remote, uint16_t port)
+    {
+        // Reached from ~udp_tunnel, so this must not throw.  The address came from us in the first
+        // place, so failing to parse it back would be a bug rather than bad input.
         try
         {
-            netaddr = srouter::NetworkAddress{remote};
+            srouter::NetworkAddress netaddr{remote};
+            context->router->session_endpoint().unmap_udp_remote_port(netaddr, port);
         }
         catch (const std::exception& e)
         {
-            throw std::invalid_argument{"Invalid remote address: {}"_format(e.what())};
+            log::error(logcat, "Failed to release UDP tunnel to {}:{}: {}", remote, port, e.what());
         }
-
-        context->router->session_endpoint().unmap_udp_remote_port(netaddr, port);
     }
 
     static snode_path to_snode_path(const srouter::path::Path::Info& info)

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -65,7 +65,7 @@ namespace session::router
         context->router->on_disconnected(std::move(callback), with_path, persist);
     }
 
-    tunnel_info SessionRouter::establish_udp(
+    std::optional<tunnel_info> SessionRouter::establish_udp(
         std::string_view remote,
         uint16_t dest_port,
         std::function<void(tunnel_info)> on_established,
@@ -92,7 +92,11 @@ namespace session::router
         quic::Address src{"::1"s, 0};
         quic::Address dest{"::1"s, dest_port};
 
-        auto [local_port, session] = context->router->session_endpoint().map_udp_remote_port(netaddr, dest_port);
+        auto mapped = context->router->session_endpoint().map_udp_remote_port(netaddr, dest_port);
+        if (!mapped)
+            return std::nullopt;
+
+        auto& [local_port, session] = *mapped;
 
         // Total tunnel overhead from outer UDP payload to inner payload:
         // outer QUIC packet framing (44) + path onion (41) + session encryption (37)


### PR DESCRIPTION
Adds support for fast-failing establish_udp when given a relay address that does not have an RC: we now return nullopt, rather than a tunnel_info, explicitly to signal that no actual tunnel was created.  Previously this was fast-failing internally, but the actual result wasn't signaled until the timer fired.