### PR TITLE
Embedded client TCP tunnel support

### DIFF
--- a/contrib/libsession-router_jank_test.cpp
+++ b/contrib/libsession-router_jank_test.cpp
@@ -10,6 +10,8 @@
 
 extern "C"
 {
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <unistd.h>
 }
 
@@ -25,6 +27,51 @@ static std::string_view failure_reason(session::router::tunnel_failure f)
         case tunnel_failure::timeout: return "session timed out";
     }
     return "unknown failure";
+}
+
+// Connects to a mapped TCP port and makes a request on it, reporting how long the whole thing took.
+// Used to exercise the promise that a connection made before the session is up is held rather than
+// refused: it is called immediately after establish_tcp() returns, when the session cannot yet exist.
+static void probe_tunnel(uint16_t local_port, std::string path)
+{
+    auto start = std::chrono::steady_clock::now();
+
+    int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+        std::cerr << "\n\x1b[31;1mprobe: socket() failed\x1b[0m\n";
+        return;
+    }
+
+    sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(local_port);
+    addr.sin6_addr = in6addr_loopback;
+
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+    {
+        std::cerr << "\n\x1b[31;1mprobe: connect to [::1]:" << local_port << " failed\x1b[0m\n";
+        ::close(fd);
+        return;
+    }
+
+    auto req = "GET " + path + " HTTP/1.0\r\nHost: tunnel\r\n\r\n";
+    ::send(fd, req.data(), req.size(), 0);
+
+    std::string resp;
+    char buf[4096];
+    while (auto n = ::recv(fd, buf, sizeof(buf), 0))
+    {
+        if (n < 0)
+            break;
+        resp.append(buf, static_cast<size_t>(n));
+    }
+    ::close(fd);
+
+    auto ms = std::chrono::round<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+    auto status = resp.substr(0, resp.find('\r'));
+    std::cout << "\n\x1b[35;1mprobe: " << resp.size() << "B in " << ms << "ms -- " << status << "\x1b[0m\n\n"
+              << std::flush;
 }
 
 int main(int argc, char** argv)
@@ -46,10 +93,23 @@ int main(int argc, char** argv)
     std::string target{argv[1]};
 
     int port = 12345; // Default, but updated if target ends with :PORT
-    if (std::smatch m; std::regex_match(target, m, std::regex{"(.*):(\\d+)$"})) {
-        port = std::stoi(m[2]);
+    // Several comma-separated ports may be given, which maps each of them to the same remote; that
+    // exercises multiple mappings sharing one session (and one tunnel connection).
+    std::vector<uint16_t> tcp_ports;
+    if (std::smatch m; std::regex_match(target, m, std::regex{"(.*):([\\d,]+)$"}))
+    {
+        std::string ports = m[2];
+        for (size_t pos = 0; pos < ports.size();)
+        {
+            auto comma = ports.find(',', pos);
+            tcp_ports.push_back(static_cast<uint16_t>(std::stoi(ports.substr(pos, comma - pos))));
+            pos = comma == std::string::npos ? ports.size() : comma + 1;
+        }
+        port = tcp_ports.front();
         target = m[1];
     }
+    if (tcp_ports.empty())
+        tcp_ports.push_back(static_cast<uint16_t>(port));
 
     auto srouter = std::make_unique<session::router::SessionRouter>(std::filesystem::path{"jank.ini"});
 
@@ -59,7 +119,11 @@ int main(int argc, char** argv)
     // Holding these is what keeps the tunnels up; dropping them releases them (and, for TCP, closes
     // any connections established through it).
     session::router::udp_tunnel tunnel;
-    session::router::tcp_tunnel tcp;
+    std::vector<session::router::tcp_tunnel> tcps;
+
+    // Opens the TCP tunnel before the session exists and connects to it straight away, to exercise
+    // the documented promise that such a connection is held rather than refused.
+    const bool early_probe = std::getenv("SR_TCP_EARLY") != nullptr;
 
     bool first_conn = true;
     srouter->on_connected([&] {
@@ -69,6 +133,35 @@ int main(int argc, char** argv)
         std::cout << "\n\x1b[32;1mSession Router connected!\x1b[0m\n\n";
         conn_prom.set_value();
     });
+    auto open_tcp = [&srouter, &target, early_probe](uint16_t port) -> session::router::tcp_tunnel {
+        auto t = srouter->establish_tcp(
+            target,
+            port,
+            [port](auto info) {
+                std::cout << "\n\x1b[32;1mTCP tunnel ready; remote port " << port << " reachable at [::1]:"
+                          << info.local_port << "\x1b[0m\n\n"
+                          << std::flush;
+            },
+            [](auto failure) {
+                std::cerr << "\n\x1b[31;1mTCP tunnel failed: " << failure_reason(failure) << "\x1b[0m\n\n"
+                          << std::flush;
+            });
+
+        if (t)
+            std::cout << "\n\x1b[32;1mTCP bound to [::1]:" << t->local_port << " -> " << target << ":" << port
+                      << "\x1b[0m\n\n";
+        else
+            std::cout << "\n\x1b[31;1mNo TCP tunnel: " << target
+                      << " is unreachable or does not accept tunnelled TCP\x1b[0m\n\n";
+
+        // With SR_TCP_EARLY set this fires while the session is still coming up, which is the case
+        // the API documents (and which waiting for on_established would never reach).
+        if (t && early_probe)
+            std::thread{probe_tunnel, t->local_port, "/index.txt"}.detach();
+
+        return t;
+    };
+
     try
     {
         conn_prom.get_future().get();
@@ -104,6 +197,11 @@ int main(int argc, char** argv)
         });
 
         target = resolve_prom.get_future().get();
+
+        if (early_probe)
+            for (auto p : tcp_ports)
+                tcps.push_back(open_tcp(p));
+
 
         tunnel = srouter->establish_udp(
             target,
@@ -156,31 +254,10 @@ int main(int argc, char** argv)
               << "    kill -SIGUSR2 " << pid << " -- re-open TCP tunnel\n"
               << "    Ctrl-C -- shut down\x1b[0m\n\n\n";
 
-    auto open_tcp = [&srouter, &target, port]() -> session::router::tcp_tunnel {
-        auto t = srouter->establish_tcp(
-            target,
-            port,
-            [port](auto info) {
-                std::cout << "\n\x1b[32;1mTCP tunnel ready; remote port " << port << " reachable at [::1]:"
-                          << info.local_port << "\x1b[0m\n\n"
-                          << std::flush;
-            },
-            [](auto failure) {
-                std::cerr << "\n\x1b[31;1mTCP tunnel failed: " << failure_reason(failure) << "\x1b[0m\n\n"
-                          << std::flush;
-            });
+    if (tcps.empty())
+        for (auto p : tcp_ports)
+            tcps.push_back(open_tcp(p));
 
-        if (t)
-            std::cout << "\n\x1b[32;1mTCP bound to [::1]:" << t->local_port << " -> " << target << ":" << port
-                      << "\x1b[0m\n\n";
-        else
-            std::cout << "\n\x1b[31;1mNo TCP tunnel: " << target
-                      << " is unreachable or does not accept tunnelled TCP\x1b[0m\n\n";
-
-        return t;
-    };
-
-    tcp = open_tcp();
 
     std::thread sig_thread{[&] {
         while (srouter)
@@ -192,7 +269,7 @@ int main(int argc, char** argv)
                 case SIGHUP:
                     std::cout << "\n\n\n\x1b[33;1mHangup signal received; closing tunnels\x1b[0m\n\n\n";
                     tunnel.reset();
-                    tcp.reset();
+                    tcps.clear();
                     break;
                 case SIGUSR1:
                 {
@@ -206,7 +283,9 @@ int main(int argc, char** argv)
                 }
                 case SIGUSR2:
                     std::cout << "\n\n\n\x1b[32;1mSIGUSR2 received: (re-)opening TCP tunnel\x1b[0m\n";
-                    tcp = open_tcp();
+                    tcps.clear();
+                    for (auto p : tcp_ports)
+                        tcps.push_back(open_tcp(p));
                     break;
                 default:
                     std::cout << "\n\n\n\x1b[33;1mSignal " << signo << " received, shutting down\x1b\[0m\n\n\n";

--- a/contrib/libsession-router_jank_test.cpp
+++ b/contrib/libsession-router_jank_test.cpp
@@ -15,6 +15,18 @@ extern "C"
 
 using namespace std::literals;
 
+static std::string_view failure_reason(session::router::tunnel_failure f)
+{
+    using session::router::tunnel_failure;
+    switch (f)
+    {
+        case tunnel_failure::unreachable: return "remote is unreachable";
+        case tunnel_failure::no_tcp: return "remote does not accept tunnelled TCP";
+        case tunnel_failure::timeout: return "session timed out";
+    }
+    return "unknown failure";
+}
+
 int main(int argc, char** argv)
 {
     if (argc <= 1)
@@ -44,8 +56,10 @@ int main(int argc, char** argv)
     std::promise<void> prom;
     std::promise<void> conn_prom;
 
-    // Holding this is what keeps the tunnel up; dropping it releases it.
+    // Holding these is what keeps the tunnels up; dropping them releases them (and, for TCP, closes
+    // any connections established through it).
     session::router::udp_tunnel tunnel;
+    session::router::tcp_tunnel tcp;
 
     bool first_conn = true;
     srouter->on_connected([&] {
@@ -105,9 +119,7 @@ int main(int argc, char** argv)
             [&prom](auto failure) {
                 try
                 {
-                    throw std::runtime_error{
-                        failure == session::router::tunnel_failure::unreachable ? "Remote is unreachable!"
-                                                                               : "Session timed out!"};
+                    throw std::runtime_error{"UDP tunnel failed: "s + std::string{failure_reason(failure)}};
                 }
                 catch (...)
                 {
@@ -144,15 +156,31 @@ int main(int argc, char** argv)
               << "    kill -SIGUSR2 " << pid << " -- re-open TCP tunnel\n"
               << "    Ctrl-C -- shut down\x1b[0m\n\n\n";
 
-    /*
-    srouter.map_tcp_remote_port(std::string{argv[1]}, port,
-        [&](auto tunnel_info) {
-          std::cout << "\n\nTCP bound to port " << tunnel_info.local_port << "\n\n";
-        },
-        [&](auto error_str) {
-          std::cerr << "\nTCP Tunnel map error: " << error_str << "\n";
-        });
-    */
+    auto open_tcp = [&srouter, &target, port]() -> session::router::tcp_tunnel {
+        auto t = srouter->establish_tcp(
+            target,
+            port,
+            [port](auto info) {
+                std::cout << "\n\x1b[32;1mTCP tunnel ready; remote port " << port << " reachable at [::1]:"
+                          << info.local_port << "\x1b[0m\n\n"
+                          << std::flush;
+            },
+            [](auto failure) {
+                std::cerr << "\n\x1b[31;1mTCP tunnel failed: " << failure_reason(failure) << "\x1b[0m\n\n"
+                          << std::flush;
+            });
+
+        if (t)
+            std::cout << "\n\x1b[32;1mTCP bound to [::1]:" << t->local_port << " -> " << target << ":" << port
+                      << "\x1b[0m\n\n";
+        else
+            std::cout << "\n\x1b[31;1mNo TCP tunnel: " << target
+                      << " is unreachable or does not accept tunnelled TCP\x1b[0m\n\n";
+
+        return t;
+    };
+
+    tcp = open_tcp();
 
     std::thread sig_thread{[&] {
         while (srouter)
@@ -162,8 +190,9 @@ int main(int argc, char** argv)
             switch (signo)
             {
                 case SIGHUP:
-                    std::cout << "\n\n\n\x1b[33;1mHangup signal received; closing UDP tunnel\x1b[0m\n\n\n";
+                    std::cout << "\n\n\n\x1b[33;1mHangup signal received; closing tunnels\x1b[0m\n\n\n";
                     tunnel.reset();
+                    tcp.reset();
                     break;
                 case SIGUSR1:
                 {
@@ -176,7 +205,8 @@ int main(int argc, char** argv)
                     break;
                 }
                 case SIGUSR2:
-                    std::cout << "\n\x1b[31;1mSIGUSR2 received: TODO FIXME: reopen TCP tunnel\x1b[0m\n\n";
+                    std::cout << "\n\n\n\x1b[32;1mSIGUSR2 received: (re-)opening TCP tunnel\x1b[0m\n";
+                    tcp = open_tcp();
                     break;
                 default:
                     std::cout << "\n\n\n\x1b[33;1mSignal " << signo << " received, shutting down\x1b\[0m\n\n\n";

--- a/docs/tcp-over-quic.md
+++ b/docs/tcp-over-quic.md
@@ -1,238 +1,133 @@
-# "embedded" TCP-over-QUIC
+# Tunnelled TCP
 
-In order for Session Router to work in an embedded version (which I will call "embedded" in this
-document), which Session Router cannot create TUN device (either because the host OS doesn't support them,
-or because Session Router needs to run without permissions to manage them) Session Router needs a solution for
-sending TCP data from the device to a remote Session Router client (i.e. a snapp, a snode, or another
-embedded client).  Since the vast majority of network connectivity relies on TCP stream
-connections, not supporting them would be a severe limitation of a Session Router library that would make
-it nearly useless.
+Session Router carries TCP for embedded clients by tunnelling it inside a QUIC connection nested in
+the session's data channel.
 
-Traditional "full" Session Router does not need to solve this problem: it creates virtual IPs on the TUN
-interface that map to every looked-up `.loki` address and then the host system's in-kernel TCP layer
-handles the intricacies of TCP including acknowledgement, retry, and so on.  While there are
-user-space TCP implementations available, they are generally incomplete, unmaintained, or both,
-which would mean substantial work and ongoing maintenance for us to adopt or reimplement such a
-user-space TCP layer, for which we would most likely be the only user and contributor.
+An embedded client (one linking `libsessionrouter-core`, with no permission or ability to create a TUN
+device) cannot put raw IP packets on the wire the way a full client does, and cannot obtain raw IP
+packets for its own application's loopback socket either.  Session path data is also deliberately
+unreliable — encapsulated packets carried as QUIC datagrams between hops, with no acknowledgement,
+sequencing or retransmission anywhere along the way — so something has to supply reliability in
+process.  Rather than implement a TCP stack to do it, we nest a QUIC connection inside the session and
+let it provide retransmission, ordering, flow control, congestion control and per-stream error codes.
 
-Instead this proposal is for Session Router to support a tunneled TCP stream mode where TCP traffic is
-carried over Session Router via a subset of the
-[QUIC](https://datatracker.ietf.org/doc/draft-ietf-quic-transport/) protocol.  Unlike TCP, QUIC has
-several well-maintained user-space implementations which allow us to use, rather than create, a
-well-maintained QUIC implementation.
+## Scope
 
-## Overview
+Supported: **an embedded client connecting out to a full client.**  The embedded side initiates; the
+full (tun) side accepts and terminates each stream into a real TCP connection to its own tun address.
 
-The high-level strategy of how we handle such a stream connection is to have TCP connections
-established only within the local device.  A embedded application would invoke a Session Router call to
-establish such a connection to proxy to a remote host by Session Router name and TCP port.  This would
-first establish a Session Router connection to the remote host, then open a QUIC connection over it and
-start listening for TCP connections on a local port.  When a new TCP connection is established on
-this port Session Router will establish a new QUIC stream over the existing connection, specifying the
-destination port while initializing the stream.  (The client is free to establish as many TCP
-connections as it wants: each one becomes a separate QUIC stream).
+Not supported, deliberately:
 
-The situation is similar for the receiving Session Router client: it would listen for incoming QUIC
-connections on the local Session Router IP and, when establishing a QUIC stream, would establish a local
-TCP connection to the requested port on the Session Router IP.  Any incoming stream data is then forwarded
-into this TCP connection, and any responses are sent back via the QUIC stream.
+- **Inbound TCP to an embedded client.**  An embedded client cannot accept tunnelled connections.
+  Earlier drafts of this document proposed a registration callback for this, plus SYN interception on
+  full clients wanting to reach an embedded one; none of that is built.
+- **Relays.**  A relay is reachable by QUIC natively, so `establish_udp` already covers everything
+  needed there.
 
-## Example
+## Data path
 
-For example, suppose `snap7.loki` is a Session Router snapp with a web server listening on port 80 and a
-embedded client `omg42.loki` wants to connect to it to retrieve a cat photo.  With a full
-Session Router client, the DNS request for `omg56789.loki` triggers creation of a virtual IP on the TUN
-device, returns the IP to the system, and any TCP packets sent to this IP are forwarded to the
-primary Session Router IP of `azfoj123.loki`, where an HTTP server is ready and waiting to provide cat
-photos.
+    ┌ embedded client ─────────┐                              ┌ full client ───────────┐
+    │ application              │                              │ service                │
+    │ TCP -> [::1]:47165 ──────│─┐                            │ TCP 10.0.0.1:80 <──────│─┐
+    ├──────────────────────────┤ │                            ╞════════════════════════╡ │
+    │ session router (in app)  │ │                            │ session router         │ │
+    │ one QUIC stream per conn │ └─ ... session router path ─┐ │                        │ │
+    │ inside one QUIC conn ────│────  (unreliable datagrams) └─│─> stream -> TCP connect┘ │
+    │ [::1]:47165 <────────────│─┐                            │ to its own tun address   │
+    └──────────────────────────┘ └────────────────────────────│──────────────────────────┘
 
-With a embedded client, this process will looks a little different: the client will first make a
-call to the embedded library (rather than a DNS request) specifying the Session Router host name and TCP
-port it wants to connect to (note that this is pseudo-code; the actual implementation calls will
-have to deal with various details such as connection delays and timeouts that are omitted here):
+The application connects to a port on `[::1]` that `establish_tcp` hands back.  Each connection to
+that port opens one stream on the tunnel's QUIC connection; the far end reads the destination port
+from the head of the stream and makes a matching TCP connection locally.  Both directions are then
+just data on the stream.
 
-    result = session_router_stream_connect(session_router_addr, port)
-    if result->connection_established:
-        http_get("http://" + result->local_address + ":" + result->local_port + "/cat.jpg")
+## Wire details
 
-Here `http_get` would need no knowledge of Session Router at all: it will simply connect via TCP to an
-address such as `127.0.0.1:4716` for the HTTP request.  It will send the request, and receive it,
-over this localhost TCP socket.
+**Stream preamble.**  The first two bytes of each stream are the destination port, big-endian.  The
+accepting side buffers until it has both, then connects; anything already received beyond the preamble
+is written to the socket ahead of whatever the socket subsequently carries.  Port 0 is refused.
 
-Internally, Session Router will have established a QUIC connection to the remote host, and started
-listening for TCP connections on the localhost port.  When `http_get` establishes a TCP connection
-on this local port it will create a QUIC stream on the established QUIC connection and forward all
-stream data received from the TCP connection into the QUIC stream, and any data that comes back over
-the QUIC stream will similarly be copied into the localhost TCP connection.
+**Capability advertisement.**  A client that can accept tunnelled TCP sets `protocol_flag::TCP_TUNNEL`
+(`1 << 5`) in its client contact, which in practice means any client with a tun device.  An initiator
+that already holds a contact without that flag refuses to map a port at all, rather than mapping one
+that could never carry anything; if the contact only arrives later and lacks the flag, the failure is
+reported as `tunnel_failure::no_tcp`.
 
-Effectively the data path of data send from the app on omg42.loki to the HTTP snapp on omg42.loki
-looks like this:
+Note this is a *new* flag rather than 1.0.x's `QUIC_TUNNEL` (`1 << 1`), which advertised the opposite
+role — "I am embedded, reach me via a tunnel" — and was therefore set by exactly the clients that
+cannot accept one.
 
-    ┌omg42.loki────────────┐                             ┌snap7.loki───────────┐
-    │ Main app thread      │                             │ HTTP                │
-    │ TCP localhost:4567 ─>│─┐                           │ TCP 172.16.0.1:80 <─│─┐
-    ├──────────────────────┤ │                           ╞═════════════════════╡ │
-    │ embedded (in app)  │ │                           │ Session Router (on host)   │ │
-    │ TCP localhost:4567 <─│─┘                         ┌>│─> QUIC UDP          │ │
-    │           QUIC UDP ─>│───... Session Router routers ...─┘ │ TCP 172.16.0.1:80 ─>│─┘
-    └──────────────────────┘                             └─────────────────────┘
+**No encryption of its own (yet).**  The inner connection needs neither authentication nor encryption:
+the session layer already encrypts end to end and the path layer onion-encrypts.  It currently uses a
+fixed, well-known keypair as a stand-in, which costs a TLS handshake and a second AEAD pass.  Both go
+away when libquic gains null crypto.
 
-(These connections are all bi-direction, so any TCP stream data replied from omg42.loki follows the
-same path in reverse.)
+**Packet sizing.**  The inner connection is capped at the QUIC minimum (1200 bytes).  An inner packet
+becomes a 1278-byte session message once session and path overhead (78 bytes) are added, which rides in
+a single path datagram as long as the outer hop's payload is at least 1324 bytes; below that it is
+split in two and both halves must survive.  Dropping the inner cap to 1076 would make splitting
+impossible on any path, but libquic currently refuses a cap below 1200.
 
-## Implementation details/notes
+**Idle handling.**  QUIC closes a connection with no activity at all on it, which would kill a TCP
+connection that is merely idle, so the inner connection sends keep-alive pings.  To avoid paying for
+those on a tunnel nobody is using, the inner connection is torn down a minute after its last stream
+goes away, and rebuilt on demand.
 
-Implementation library: `ngtcp2` is a robust, maintained library that fits our needs well.
+## Backpressure
 
-### Not a general QUIC server/client
+Both directions are flow-controlled, since either end can be the slow one:
 
-The QUIC tunnel described here is *only* for Session Router TCP streams; it is not intended to be
-interoperable with general QUIC clients, which allows us some leeway to not support some aspects of
-QUIC that are of no advantage over a Session Router conversation.
+- application → tunnel: stream watermarks stop reading from the local socket when the tunnel falls
+  behind, and resume when it drains.
+- tunnel → application: a bufferevent's output buffer grows without limit and so signals nothing on
+  its own, so the stream is paused once the queued output passes a threshold and resumed from the
+  write callback once it drains.
 
-### No encryption
+## Close semantics
 
-Since Session Router traffic is itself encrypted and private, the built-in TLS layers of QUIC are something
-that we don't need or want.  Thus the QUIC implementation used will simply use no-op encryption to
-pass data and avoid/ignore certificates.  (`ngtcp2`, in particular, allows pluggable authentication
-to allow this).
+Distinguishing an orderly close from a failure matters: conflating them truncates transfers silently,
+which is exactly what went wrong in the previous (lokinet 0.9.x, ngtcp2) implementation of this idea.
 
-### No address verification
+| Event | Action |
+|---|---|
+| Local TCP EOF (clean) | send FIN on the stream; keep receiving (a real half-close) |
+| Local TCP error | close the stream with `TCP_FAILURE` |
+| Stream FIN received | shut down the socket's write side, but only once queued output has drained |
+| Stream closed with an error | drop the local connection without a clean FIN |
+| Accepting side cannot connect | close the stream with `CONNECT_FAILED` |
+| Accepting side refuses the port | close the stream with `REFUSED` |
 
-QUIC recommends address verification (among other things, to avoid amplification attacks).  Session Router
-connections already provide this and so we can safely not use it.
+## Using it
 
-### Stream establishing
-
-Establishing a QUIC stream requires sending additional information during connection: namely the
-target connection port.  Thus establishing a new stream will require some additional data to be
-passed, likely as the initial stream data.  (Specification of how this data is to be encoded is not
-yet specified).
-
-### Incoming TCP-over-QUIC connections
-
-Handling of incoming connections to a embedded client will require a similar process, but in
-reverse:
-
-- the client starts listening on a localhost TCP port
-- the client makes a call to embedded to inform it of this available listening port
-- incoming QUIC tunneled streams attempting to connect to that registered port are accepted and
-  establish a new TCP connection as long as the stream stays open; data is forwarded between the two
-  connections.
-- Should the client require end-point verification embedded will provide a function that can look
-  up the remote Session Router address based on the source port of the TCP connection.  (This is different
-  from but analogous to a snapp doing a reverse DNS lookup on the source address to determine the
-  remote address).
-
-Note: to be externally reachable by other Session Router clients, a embedded client would have to publish
-an introset; this introset would also include an additional flag indicating that TCP connections
-must be tunneled through a TCP-over-QUIC connection.
-
-Note 2: we additionally may want to signal during connection that new TCP connections back to us
-should be done over a QUIC tunnel, which requires also adding a flag when establishing the
-Session Router conversation.
-
-### Non-tunneled incoming TCP connections
-
-Without a controllable TCP stack we have no ability to accept these, however since the introset (and
-conversation initiation) indicates that TCP should be tunneled, we should just drop these packets.
-
-## Session Router implementation notes
-
-### Outbound connections -- embedded
-
-The application makes a embedded library call such as
-
-    session_router_stream_result res;
-    session_router_outbound_stream(&res, "some-snapp.loki", 2345);
-
-This initiates an outbound connection to the given Session Router remote, asking to connect to port 2345 on
-the remote.  Plainquic begins listening on a random localhost port, and returns this via an entry in
-`res`.  New connections establishes to this localhost port initiate new streams on the quic
-connection which are tunneled to the remote end.
-
-### Inbound connections -- embedded
-
-The application needs to start listening on one or more TCP ports (e.g. on localhost, but doesn't
-have to be) and then registers a callback with Session Router about the availability of this port for
-incoming plainquic connections by setting up a callback:
-
-```C
-    int accept_inbound(const char *session_router_addr, uint16_t port, sockaddr *addr, void *context) {
-        // session_router_addr is the remote Session Router client trying to establish a stream
-        // port is the port they are trying to reach
-        // If the client is allowed then set the local TCP socket address that the tunnel should
-        // connect to in `addr` (which is big enough to allow either sockaddr_in or sockaddr_in6)
-        sockaddr_in* a = (sockaddr_in*)addr;
-        a->sin_family = AF_INET;
-        a->sin_addr = INADDR_LOOPBACK;
-        a->sin_port = htons(5678); // NB: Doesn't have to be the passed-in `port`
-        return 0;
-        // If this callback doesn't handle the requested port (will try other callbacks):
-        return -1;
-        // If this callback does handle it and the connection should be refused:
-        return -2;
-        // (Return values other than 0/-1/-2 are reserved and should not be used).
-    }
-    session_router_inbound_stream(&accept_inbound, NULL /*context*/);
-```
-or, for the very simple case where connections should be available on some localhost port:
-```C
-    // All incoming tunneled connections for port 5678 should go to localhost:5678
-    session_router_inbound_stream_simple(5678);
+```c++
+// Holding the claim is what keeps the tunnel up.
+session::router::tcp_tunnel tcp = router.establish_tcp(
+        "kcpyawm9se7trdbzncimdi5t7st4p5mh9i1mg7gkpuubi4k4ku1y.sesh", 80,
+        [](auto info) { /* ready: connect to [::1]:info.local_port */ },
+        [](auto failure) { /* unreachable, unsupported, or timeout */ });
 ```
 
-When a new plainquic connection arrives, if such a callback has been registered it will be called to
-determine whether the connection should be accepted and, if it is, where streams opened on that
-connection should be sent.  (For the simple version, all inbound connections on port 5678 would be
-accepted and would be forwarded to localhost:5678; inbound connections for other ports would be
-refused).
+The application then makes ordinary TCP connections to `[::1]:tcp->local_port`, as many as it likes;
+each becomes a separate connection to port 80 on the remote.
 
-Each new plainquic stream initiated by the remote connection then establishes a new TCP connection
-to the IP/port set by the callback.
+Releasing the claim (destroying it, or calling `reset()`) closes the listening port *and* the
+connections established through it.  Asking for a remote and port that is already mapped hands back
+another claim on the same mapping rather than a new one, so releasing one claim never pulls the tunnel
+out from under another holder.
 
-### Outbound connections - full Session Router
+## Acceptor policy
 
-When attempting to connect to a client who has indicated in its introset that it requires plainquic
-connections then plainquic will bind to and listen on the virtual (tun) TCP/IP port and establish a
-plainquic connection to the remote embedded on the given port.  (Future connections to this port
-will establish new streams on the existing connection).
+The accepting side connects to **its own tun address** on whatever port the stream asks for.  Any port
+is allowed, which is parity with how tun mode already behaves: a remote sending raw IP packets to a
+full client's tun address can likewise reach anything listening there.  If that ever needs narrowing,
+an allow-list belongs in config rather than in the tunnel.
 
-Setting up the initial listener involves intercepting the initial TCP connection attempt (i.e. the
-SYN packet), starting to listen on it while simultaneously initiating the plainquic connection over
-session_router.  It may work sufficiently well (investigation required) to simply drop this initial SYN
-packet and let the initiator retry in a few moments to attack to the new listener which now goes
-into the plainquic listener which establishes a new stream.
+## Known gaps
 
-Thereafter the local application simply talks to this local listener and all stream data gets
-tunneled over Session Router to the remote embedded.
-
-### Inbound connections - full Session Router
-
-This is fairly simple: when incoming quic-tunneled packets arrive we start up a plainquic server (if
-not already running), deliver the packets into it, and it tunnels incoming stream data into TCP
-connections to the primary Session Router IP (using the IP mapped to the Session Router endpoint as the source
-address).
-
-
-TODO:
-- Add quic protocol type to llarp/service/protocol_types.hpp
-- Convert stuff in plainquic code to use Session Router structures (e.g. logging, address encapsulation)
-- Add handler for QUIC packets to llarp/handlers/tun.cpp that see that protocol type and forward the
-  packet off to the quic server to handle.
-- Get at the uvw event loop from the quic code so that we can put the plainquic stuff onto it rather
-  than spinning up its own event loop.  I was thinking about something like:
-  `virtual std::shared_ptr<void> get_uvw_loop() { return nullptr; }` in ev.h, and an override that
-  returns the uvw event loop in the ev_libuv.h subclass (the type erasure through the shared_ptr<void>
-  means ev.h doesn't have to depend on any uvw.h headers).  Then the quic code can just do something
-  like:
-    auto uv_loop = std::static_pointer_cast<uvw::Loop>(ev->get_uvw_loop());
-    if (not uv_loop) { die("horribly"); }
-- convert the crap in the `main` functions copied from plainquic test code to exposed library calls.
-- decide whether we start up a quic server and/or client on demand, or just always start it.
-
-
-Outgoing conns:
-- Add "supported protocols" item to introset and (for embedded) leave off IPv4/v6 flags, but add
-  quic protocol flag.
-
+- Null crypto in libquic, which removes the inner handshake round trip (via unconditional early data)
+  and the second AEAD pass.
+- A sub-1200 inner packet cap, so an inner packet never splits across two path datagrams.
+- Nothing here handles IPv4: the accepting side connects to the tun's IPv6 address only, deliberately,
+  as IPv4 is on its way out.  A tun client with no IPv6 address cannot accept tunnelled TCP.
+- Nested congestion control (the inner connection's BBR inside each hop's BBR, over a channel whose
+  congestion shows up as deep buffering rather than loss) is unmeasured.

--- a/docs/tcp-over-quic.md
+++ b/docs/tcp-over-quic.md
@@ -57,10 +57,15 @@ Note this is a *new* flag rather than 1.0.x's `QUIC_TUNNEL` (`1 << 1`), which ad
 role — "I am embedded, reach me via a tunnel" — and was therefore set by exactly the clients that
 cannot accept one.
 
-**No encryption of its own (yet).**  The inner connection needs neither authentication nor encryption:
-the session layer already encrypts end to end and the path layer onion-encrypts.  It currently uses a
-fixed, well-known keypair as a stand-in, which costs a TLS handshake and a second AEAD pass.  Both go
-away when libquic gains null crypto.
+**No encryption of its own.**  The inner connection needs neither authentication nor encryption: the
+session layer already encrypts end to end, the path layer onion-encrypts, and the session has already
+authenticated the peer.  It therefore uses libquic's `DangerouslyUnencryptedCreds`, which replaces
+QUIC's AEAD with a no-op and its TLS handshake with a fixed exchange carrying only the transport
+parameters.  That removes a second encryption pass over every byte and the gnutls handshake that used
+to precede any data.
+
+Both ends must be doing this: such a connection cannot talk to an ordinary QUIC endpoint and fails the
+handshake rather than falling back, which is what the `TCP_TUNNEL` capability flag exists to avoid.
 
 **Packet sizing.**  The inner connection is capped at the QUIC minimum (1200 bytes).  An inner packet
 becomes a 1278-byte session message once session and path overhead (78 bytes) are added, which rides in
@@ -124,9 +129,26 @@ an allow-list belongs in config rather than in the tunnel.
 
 ## Known gaps
 
-- Null crypto in libquic, which removes the inner handshake round trip (via unconditional early data)
-  and the second AEAD pass.
-- A sub-1200 inner packet cap, so an inner packet never splits across two path datagrams.
+- The first TCP connection through a mapping waits a path round trip for the inner handshake.
+  Subsequent ones do not: the connection persists until a minute after its last stream, so this is one
+  RTT per inner connection rather than per TCP connection.
+
+  Opening the inner connection when the mapping is made, rather than on first use, would not help:
+  establish_tcp() hands back the bound port synchronously, so an application can connect straight away
+  without waiting for the session, and that connection already starts the inner handshake, whose
+  Initial waits in the pre-establishment queue and flushes as soon as the session is up.  Opening it
+  earlier would queue the same packet slightly sooner, for every mapping including unused ones, each
+  with its keep-alives -- which is what the idle teardown exists to avoid.
+
+  The remaining round trip is not a scheduling problem: the inner handshake cannot complete before the
+  session that carries it exists.
+
+  Skipping the handshake entirely is a bigger job than "we have no secrets to establish": QUIC only
+  allows stream data in 0-RTT or 1-RTT packets, so it means driving ngtcp2's 0-RTT space directly --
+  null 0-RTT keys, a faked early-data acceptance, and pre-provisioned server transport parameters
+  (which resumption normally supplies) that must not overstate what the server actually allows.
+- A sub-1200 inner packet cap, so an inner packet never splits across two path datagrams; libquic
+  currently refuses a cap below the QUIC minimum.
 - Nothing here handles IPv4: the accepting side connects to the tun's IPv6 address only, deliberately,
   as IPv4 is on its way out.  A tun client with no IPv6 address cannot accept tunnelled TCP.
 - Nested congestion control (the inner connection's BBR inside each hop's BBR, over a channel whose

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 
 set(LIBQUIC_BUILD_TESTS OFF CACHE BOOL "")
-sessiondep_or_submodule(liboxenquic 1.8.0 oxen-libquic oxen::quic)
+sessiondep_or_submodule(liboxenquic 1.9.0 oxen-libquic oxen::quic)
 
 
 # libcrypt defaults, only on with macos and non static linux

--- a/include/session/router.hpp
+++ b/include/session/router.hpp
@@ -69,6 +69,12 @@ namespace session::router
         /// reached at all until it rejoins.  Attempting it again immediately is pointless, but the
         /// verdict is not permanent: it is re-checked on each attempt.
         unreachable,
+
+        /// The remote advertises that it cannot accept tunnelled TCP connections, which only a
+        /// client running a full tun interface can do.  (TCP only.)  The session itself is fine; it
+        /// is TCP that will never work with this remote, so retrying is pointless until the remote
+        /// itself changes.
+        no_tcp,
     };
 
     class SessionRouter;
@@ -113,18 +119,58 @@ namespace session::router
         const tunnel_info* operator->() const { return &_info; }
     };
 
+    /// A claim on a Session Router TCP tunnel, obtained from SessionRouter::establish_tcp().
+    ///
+    /// This behaves exactly as udp_tunnel does, and the notes there about sharing, releasing, and
+    /// outliving the SessionRouter apply here too: the mapping stays up until the last claim on it
+    /// is destroyed.
+    ///
+    /// Releasing the last claim closes the local listening port *and* the TCP connections already
+    /// established through it: holding a claim is what keeps the tunnel alive, so nothing outlives
+    /// the last one.  Keep the claim for as long as you want the connections.
+    class tcp_tunnel
+    {
+        friend class SessionRouter;
+
+        std::weak_ptr<void> _router_alive;
+        SessionRouter* _router{nullptr};
+        tunnel_info _info;
+
+        tcp_tunnel(SessionRouter& router, std::weak_ptr<void> alive, tunnel_info info);
+
+      public:
+        tcp_tunnel() = default;
+        tcp_tunnel(tcp_tunnel&& other) noexcept { *this = std::move(other); }
+        tcp_tunnel& operator=(tcp_tunnel&& other) noexcept;
+        tcp_tunnel(const tcp_tunnel&) = delete;
+        tcp_tunnel& operator=(const tcp_tunnel&) = delete;
+        ~tcp_tunnel();
+
+        /// Releases this claim now rather than at destruction, leaving the object empty.
+        void reset();
+
+        explicit operator bool() const { return _router != nullptr; }
+
+        const tunnel_info& operator*() const { return _info; }
+        const tunnel_info* operator->() const { return &_info; }
+    };
+
     using snode_path = std::vector<std::pair<std::string, std::string>>;
     using session_path = std::pair<snode_path, std::string>;
 
     class SessionRouter
     {
         friend class udp_tunnel;
+        friend class tcp_tunnel;
 
-        // Lets a udp_tunnel that outlives us know not to touch us on the way out.
+        // Lets a udp_tunnel/tcp_tunnel that outlives us know not to touch us on the way out.
         std::shared_ptr<void> _alive{std::make_shared<char>()};
 
         // Releases one claim on a UDP tunnel; the mapping goes away with the last one.
         void release_udp(const std::string& remote, uint16_t port);
+
+        // Releases one claim on a TCP tunnel; the mapping goes away with the last one.
+        void release_tcp(const std::string& remote, uint16_t port);
 
         std::unique_ptr<srouter::Context> context;
 
@@ -235,6 +281,38 @@ namespace session::router
         // Take care not to use very slow or blocking code inside the callbacks: they are called
         // from Session Router's logic thread (and so any blocking will stall Session Router).
         udp_tunnel establish_udp(
+            std::string_view remote,
+            uint16_t port,
+            std::function<void(tunnel_info)> on_established = nullptr,
+            std::function<void(tunnel_failure)> on_failed = nullptr);
+
+        // The TCP counterpart of establish_udp: establishes a session to the given remote and maps
+        // an IPv6 localhost port that the application connects to with ordinary TCP.  Each
+        // connection made to that port becomes a separate connection to `port` on the remote, so a
+        // single mapping carries as many concurrent connections as the application opens.
+        //
+        // (As with establish_udp, this does not accept SNS names: call resolve() first.)
+        //
+        // The outcomes are the same three as establish_udp, with two differences:
+        //
+        // - It also returns an empty claim (mapping nothing, no callback) if the remote's client
+        //   contact says it does not accept tunnelled TCP connections.  Only clients running a full
+        //   tun interface can terminate them, so an embedded client cannot be a destination.
+        //
+        // - `on_failed(no_tcp)` is invoked if that only becomes apparent later, i.e. we had no
+        //   client contact for the remote when the port was mapped and it turned out, once we did,
+        //   not to accept them.  As with `unreachable`, the mapping exists and the claim is real.
+        //
+        // Unlike UDP, nothing can be sent before the session is established: a TCP connection made
+        // to the mapped port before then is held until the session comes up, and dropped if it does
+        // not.
+        //
+        // `tunnel_info::suggested_mtu` is always nullopt for TCP: segment sizes are not the
+        // application's to choose.
+        //
+        // Take care not to use very slow or blocking code inside the callbacks: they are called from
+        // Session Router's logic thread (and so any blocking will stall Session Router).
+        tcp_tunnel establish_tcp(
             std::string_view remote,
             uint16_t port,
             std::function<void(tunnel_info)> on_established = nullptr,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ session_router_add_library(session-router-core
   router/router.cpp
 
   session/session.cpp
+  session/tcp_tunnel.cpp
 )
 
 if (SROUTER_FULL)

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1220,6 +1220,13 @@ namespace srouter
                 "Logging settings",
             });
 
+        // quic logs a line per stream open and close at info, which is noise for a client that
+        // tunnels TCP.  Embedded clients get nothing so that an embedding application's own
+        // oxen::logging setup is left alone.
+        const std::string default_log_levels = conf.type == config::Type::Relay ? "warn"
+            : conf.type == config::Type::FullClient                             ? "*=info, quic=warn"
+                                                                                : "";
+
         conf.define_option<std::string>(
             "logging",
             "type",
@@ -1246,15 +1253,20 @@ namespace srouter
         conf.define_option<std::string>(
             "logging",
             "level",
-            Default{
-                conf.type == config::Type::Relay            ? "warn"
-                    : conf.type == config::Type::FullClient ? "info"
-                                                            : ""},
-            [this](std::string arg) { levels = std::move(arg); },
+            Default{default_log_levels},
+            [this, defaults = default_log_levels](std::string arg) {
+                // Category settings are cumulative, so appending is all that is needed: a setting
+                // naming only categories ("tcp=debug") adjusts the defaults, while one naming a
+                // global level ("debug") resets everything before it and so replaces them.
+                levels = defaults.empty() || arg.empty() || arg == defaults ? std::move(arg) : defaults + ", " + arg;
+            },
             Comment{
                 "Minimum log severity level to print. Logging below this level will be ignored.",
                 "Can also be set to a comma-separated list of individual categories, such as:",
                 "    *=warn, logcat123=debug",
+                "",
+                "Setting only categories, without a global level, adjusts the defaults rather than",
+                "replacing them, so e.g. 'tcp=debug' keeps the default level for everything else.",
                 "",
                 "Valid log levels, in ascending order, are:",
                 "  trace, debug, info, warn, error, critical, off",

--- a/src/ev/tcp.cpp
+++ b/src/ev/tcp.cpp
@@ -1,6 +1,6 @@
 #include "tcp.hpp"
 
-#include "net/ip_packet.hpp"
+#include "util/formattable.hpp"
 #include "util/logging.hpp"
 #include "util/logging/buffer.hpp"
 
@@ -12,7 +12,16 @@ namespace srouter
 {
     static_assert(std::same_as<evutil_socket_t, TCPConnection::fd_t>);
 
-    static auto logcat = oxen::log::Cat("ev-tcp");
+    static auto logcat = oxen::log::Cat("tcp");
+
+    // Backpressure thresholds.  The stream pair stops us reading from the application when the
+    // tunnel is not keeping up; the socket pair pauses the stream when the application is not
+    // keeping up.  Both need enough hysteresis to avoid flapping on a high-latency path, where a
+    // full bandwidth-delay product of data can legitimately be in flight.
+    inline constexpr size_t STREAM_ALARM_WATER = size_t{512} * 1024;
+    inline constexpr size_t STREAM_CLEAR_WATER = size_t{64} * 1024;
+    inline constexpr size_t SOCKET_ALARM_WATER = size_t{512} * 1024;
+    inline constexpr size_t SOCKET_CLEAR_WATER = size_t{64} * 1024;
 
     constexpr auto evconnlistener_deleter = [](::evconnlistener *e) {
         log::trace(logcat, "Invoking evconnlistener deleter!");
@@ -35,18 +44,17 @@ namespace srouter
 
     static void tcp_read_cb(bufferevent *bev, void *user_arg)
     {
-        std::vector<uint8_t> buf{};
-        buf.resize(2048);
-
-        // Load data from input buffer to local buffer
-        // FIXME: handle nwrite == 0
-        auto nwrite = bufferevent_read(bev, buf.data(), buf.size());
-        buf.resize(nwrite);
-
-        log::trace(logcat, "TCP socket received {}B: {}", nwrite, buffer_printer{buf});
-
         auto *conn = reinterpret_cast<TCPConnection *>(user_arg);
         assert(conn);
+
+        std::vector<uint8_t> buf{};
+        buf.resize(evbuffer_get_length(bufferevent_get_input(bev)));
+        if (buf.empty())
+            return;
+
+        buf.resize(bufferevent_read(bev, buf.data(), buf.size()));
+
+        log::trace(logcat, "TCP socket received {}B: {}", buf.size(), buffer_printer{buf});
 
         conn->stream->send(std::move(buf));
     };
@@ -60,7 +68,12 @@ namespace srouter
     void TCPConnection::on_write_available()
     {
         log::debug(logcat, "TCP Tunnel connection, write to local conn was blocked but is now available.");
-        stream->resume();
+        if (stream->is_paused())
+            stream->resume();
+
+        // A half-close we could not act on earlier because data was still queued for the app.
+        if (_fin_received)
+            flush_and_shutdown_write();
     }
 
     static void tcp_event_cb(bufferevent *bev, short what, void *user_arg)
@@ -81,22 +94,30 @@ namespace srouter
                 : what & BEV_EVENT_CONNECTED ? "CONNECTED"
                                              : "IMPOSSIBLE");
 
-        // this is where the InboundSession confirms it established a TCP connection to the backend app
+        // This is where the accepting side confirms it established a TCP connection to the backend
+        // app; the stream is held paused until then so that no data is lost before the socket exists.
         if (what & BEV_EVENT_CONNECTED)
         {
-            log::info(logcat, "TCP connect operation finished!");
+            log::debug(logcat, "TCP connect operation finished!");
+            conn->_connected = true;
             conn->stream->resume();
+            return;
         }
+
+        // An error before the socket ever came up means we could not reach the target at all, which
+        // the far end needs to be able to tell apart from a connection that broke mid-stream.
         if (what & BEV_EVENT_ERROR)
         {
-            log::critical(logcat, "TCP Connection encountered error from bufferevent");
+            log::warning(
+                logcat,
+                "TCP Connection encountered error from bufferevent: {}",
+                evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()));
+            conn->close(conn->_connected ? tunnel_error::TCP_FAILURE : tunnel_error::CONNECT_FAILED);
+            return;
         }
-        if (what & (BEV_EVENT_EOF | BEV_EVENT_ERROR))
-        {
-            log::debug(logcat, "TCP Connection closing tunneled QUIC stream");
 
-            conn->stream->close();
-        }
+        if (what & BEV_EVENT_EOF)
+            conn->on_tcp_eof();
     };
 
     static void tcp_listen_cb(
@@ -113,6 +134,12 @@ namespace srouter
 
         // make TCPConnection here!
         auto *conn = handle->_conn_maker(bevent, fd);
+        if (!conn)
+        {
+            log::warning(logcat, "Could not tunnel incoming TCP connection from {}; dropping it", source);
+            bufferevent_free(bevent);
+            return;
+        }
 
         bufferevent_setcb(bevent, tcp_read_cb, tcp_write_cb, tcp_event_cb, conn);
         bufferevent_enable(bevent, EV_READ | EV_WRITE);
@@ -133,58 +160,92 @@ namespace srouter
     TCPConnection::TCPConnection(bufferevent *_bev, evutil_socket_t _fd, std::shared_ptr<quic::Stream> s)
         : bev{_bev}, fd{_fd}, stream{std::move(s)}
     {
-        stream->set_data_callback([this, _bev](quic::Stream &stream, std::span<const std::byte> data) mutable {
-            // libquic FIXME: would be convenient to be able to ask the stream if it's inbound or outbound
-            // here since this callback is used for both and that would make logging more clear.
-            if (stream.is_paused())
+        stream->set_data_callback([this](quic::Stream &s, std::span<const std::byte> data) {
+            if (bufferevent_write(bev, data.data(), data.size()) != 0)
             {
-                // FIXME: C++23 makes this syntax nicer
-                pending_buffer.insert(pending_buffer.end(), data.begin(), data.end());
-                return;
-            }
-            std::byte *cur = pending_buffer.data();
-            size_t written = 0;
-            while (written < pending_buffer.size())
-            {
-                constexpr size_t chunk_size = 1500;  // FIXME: this, obviously; arbitrary number
-                size_t s = std::min(chunk_size, pending_buffer.size() - written);
-                if (bufferevent_write(_bev, cur, s) != 0)
-                {
-                    // FIXME: if hypothetically quic/Session Router stream is finished sending,
-                    // so this is the last call of this callback, but socket is blocked, not
-                    // letting us write the last chunk(s) buffered, what to do?
-                    break;
-                }
-                written += s;
-                cur += s;
-            }
-            if (written < pending_buffer.size())
-            {
-                log::debug(logcat, "TCP Tunnel stream unpaused, but we failed to write all queued data.");
-                size_t new_size = pending_buffer.size() - written;
-                std::memmove(pending_buffer.data(), pending_buffer.data() + written, new_size);
-                pending_buffer.resize(new_size);
-                pending_buffer.insert(pending_buffer.end(), data.begin(), data.end());
-            }
-            if (written == pending_buffer.size())
-                pending_buffer.clear();
-            else
-            {  // we got unpaused, but clogged the (kernel?) buffer again, pause again
-                stream.pause();
-                pending_buffer.insert(pending_buffer.end(), data.begin(), data.end());
+                log::warning(
+                    logcat, "Failed to write {}B from stream (id:{}) to TCP socket", data.size(), s.stream_id());
+                close(tunnel_error::TCP_FAILURE);
                 return;
             }
 
-            if (auto rv = bufferevent_write(_bev, data.data(), data.size()); rv != 0)
-            {
-                log::debug(logcat, "TCP Tunnel refused write, pausing quic stream and buffering.");
-                pending_buffer.resize(data.size());
-                std::memcpy(pending_buffer.data(), data.data(), data.size());
-                return;
-            }
+            log::trace(logcat, "Stream (id:{}) wrote {}B to TCP buffer", s.stream_id(), data.size());
 
-            log::debug(logcat, "Stream (id:{}) wrote {}B to TCP buffer", stream.stream_id(), data.size());
+            // A bufferevent's output buffer grows without limit, so the only backpressure available
+            // here is to stop the far end once the application is visibly failing to keep up.
+            if (!s.is_paused() && evbuffer_get_length(bufferevent_get_output(bev)) >= SOCKET_ALARM_WATER)
+            {
+                log::debug(logcat, "App is behind on stream (id:{}); pausing the tunnelled stream", s.stream_id());
+                s.pause();
+            }
         });
+
+        stream->set_fin_callback([this](quic::Stream &) { on_stream_fin(); });
+
+        stream->set_close_callback([this](quic::Stream &s, uint64_t ec) {
+            if (ec != 0)
+                log::debug(logcat, "Tunnelled stream (id:{}) closed by remote with error code {}", s.stream_id(), ec);
+            finish();
+        });
+
+        stream->enable_watermarks(
+            STREAM_ALARM_WATER,
+            [this](quic::Stream &) { stop_reading(); },
+            STREAM_CLEAR_WATER,
+            [this](quic::Stream &) { resume_reading(); });
+
+        // Fire the write callback once the app has drained down to here, which is what lets us
+        // un-pause the stream and act on a deferred half-close.
+        bufferevent_setwatermark(bev, EV_WRITE, SOCKET_CLEAR_WATER, 0);
+    }
+
+    void TCPConnection::on_tcp_eof()
+    {
+        if (_fin_sent)
+            return;
+        _fin_sent = true;
+
+        log::debug(logcat, "Local TCP side closed; passing the half-close on to the tunnelled stream");
+        bufferevent_disable(bev, EV_READ);
+        stream->send_fin();
+
+        if (_write_shutdown)
+            finish();
+    }
+
+    void TCPConnection::on_stream_fin()
+    {
+        log::debug(logcat, "Tunnelled stream finished sending; shutting down our TCP write side");
+        _fin_received = true;
+        flush_and_shutdown_write();
+    }
+
+    void TCPConnection::flush_and_shutdown_write()
+    {
+        if (_write_shutdown)
+            return;
+
+        // Shutting down while data is still queued for the app would truncate it; the write
+        // watermark callback brings us back here once it drains.
+        if (evbuffer_get_length(bufferevent_get_output(bev)) > 0)
+            return;
+
+        _write_shutdown = true;
+        if (fd != -1)
+            ::shutdown(fd, SHUT_WR);
+
+        if (_fin_sent)
+            finish();
+    }
+
+    void TCPConnection::finish()
+    {
+        if (_finished)
+            return;
+        _finished = true;
+
+        if (on_done)
+            on_done();
     }
 
     void TCPConnection::stop_reading() { bufferevent_disable(bev, EV_READ); }
@@ -193,13 +254,35 @@ namespace srouter
 
     TCPConnection::~TCPConnection()
     {
+        // The stream can outlive us (the connection also holds it), so make sure nothing it does
+        // afterwards calls back into this object.  These have to be cleared before the close below,
+        // which can fire them re-entrantly.
+        if (stream)
+        {
+            stream->set_data_callback(nullptr);
+            stream->set_fin_callback(nullptr);
+            stream->set_close_callback(nullptr);
+            stream->disable_watermarks();
+
+            // Being dropped without having finished (an owner tearing the tunnel down, or a connect
+            // that failed outright) still has to take the stream down rather than leaving it open
+            // on the wire.
+            if (!_finished)
+                stream->close(_connected ? tunnel_error::TCP_FAILURE : tunnel_error::CONNECT_FAILED);
+        }
+
         bufferevent_free(bev);
         log::debug(logcat, "TCPSocket shut down!");
     }
 
     void TCPConnection::close(uint64_t ec)
     {
-        log::info(logcat, "TCP connection closing with application error code: {}", ec);
+        if (_finished)
+            return;
+
+        log::debug(logcat, "TCP connection closing with application error code: {}", ec);
+        stream->close(ec);
+        finish();
     }
 
     std::shared_ptr<TCPHandle> TCPHandle::make_server(quic::Loop &ev, tcpconn_hook cb, uint16_t port)
@@ -207,14 +290,6 @@ namespace srouter
         std::shared_ptr<TCPHandle> h{new TCPHandle(ev, std::move(cb), port)};
         return h;
     }
-
-    std::shared_ptr<TCPHandle> TCPHandle::make_client(quic::Loop &ev, quic::Address connect)
-    {
-        std::shared_ptr<TCPHandle> h{new TCPHandle{ev, std::move(connect)}};
-        return h;
-    }
-
-    TCPHandle::TCPHandle(quic::Loop &ev_loop, quic::Address connect) : _ev{ev_loop}, _connect{std::move(connect)} {}
 
     TCPHandle::TCPHandle(quic::Loop &ev_loop, tcpconn_hook cb, uint16_t p) : _ev{ev_loop}, _conn_maker{std::move(cb)}
     {
@@ -225,22 +300,29 @@ namespace srouter
     }
 
     std::shared_ptr<TCPConnection> TCPHandle::connect(
-        event_base *_ev, quic::Address src, std::shared_ptr<quic::Stream> s, uint16_t port)
+        quic::Loop &ev, const quic::Address &dest, std::shared_ptr<quic::Stream> s)
     {
-        sockaddr_in _addr = src.in4();
-        _addr.sin_port = htons(port);
-
         // NB: BEV_OPT_THREADSAFE not used because this should only ever be touched
         // by a single thread.
-        bufferevent *_bev = bufferevent_socket_new(_ev, -1, BEV_OPT_CLOSE_ON_FREE);
-
-        if (bufferevent_socket_connect(_bev, (struct sockaddr *)&_addr, sizeof(_addr)) < 0)
+        bufferevent *_bev = bufferevent_socket_new(ev.get_event_base(), -1, BEV_OPT_CLOSE_ON_FREE);
+        if (!_bev)
         {
-            log::warning(logcat, "Failed to make bufferevent-based TCP connection!");
+            log::warning(logcat, "Failed to create bufferevent for TCP connection to {}", dest);
             return nullptr;
         }
 
         auto tcp_conn = std::make_shared<TCPConnection>(_bev, -1, std::move(s));
+        tcp_conn->_connected = false;
+
+        bufferevent_setcb(_bev, tcp_read_cb, tcp_write_cb, tcp_event_cb, tcp_conn.get());
+        bufferevent_enable(_bev, EV_READ | EV_WRITE);
+
+        quic::Address target{dest};
+        if (bufferevent_socket_connect(_bev, target, static_cast<int>(target.socklen())) < 0)
+        {
+            log::warning(logcat, "Failed to make bufferevent-based TCP connection to {}!", dest);
+            return nullptr;
+        }
 
         // only set after a call to bufferevent_socket_connect
         tcp_conn->fd = bufferevent_getfd(_bev);
@@ -248,14 +330,11 @@ namespace srouter
         return tcp_conn;
     }
 
-    void TCPHandle::_init_client() {}
-
     void TCPHandle::_init_server(uint16_t port)
     {
-        sockaddr_in _tcp{};
-        _tcp.sin_family = AF_INET;
-        _tcp.sin_addr.s_addr = INADDR_ANY;
-        _tcp.sin_port = htons(port);
+        // Loopback only: the mapped port is for this device's applications, and the documented
+        // establish_*() contract hands back a port on [::1].
+        quic::Address bind_addr{"::1", port};
 
         _tcp_listener = _ev.template shared_ptr<struct evconnlistener>(
             evconnlistener_new_bind(
@@ -264,8 +343,8 @@ namespace srouter
                 this,
                 LEV_OPT_CLOSE_ON_FREE | LEV_OPT_THREADSAFE | LEV_OPT_REUSEABLE,
                 -1,
-                reinterpret_cast<sockaddr *>(&_tcp),
-                sizeof(sockaddr)),
+                bind_addr,
+                static_cast<int>(bind_addr.socklen())),
             evconnlistener_deleter);
 
         if (not _tcp_listener)
@@ -274,8 +353,7 @@ namespace srouter
                 "TCP listener construction failed: {}"_format(evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()))};
         }
 
-        _sock = evconnlistener_get_fd(_tcp_listener.get());
-        check_rv(getsockname(_sock, _bound, _bound.socklen_ptr()));
+        check_rv(getsockname(evconnlistener_get_fd(_tcp_listener.get()), _bound, _bound.socklen_ptr()));
         log::debug(logcat, "tcp listener, bound to {}", _bound);
         evconnlistener_set_error_cb(_tcp_listener.get(), tcp_err_cb);
     }

--- a/src/ev/tcp.hpp
+++ b/src/ev/tcp.hpp
@@ -14,7 +14,18 @@ namespace srouter
 {
     namespace quic = oxen::quic;
 
-    class QUICTunnel;
+    // Application error codes used when closing a tunnelled stream.  These stay well clear of
+    // libquic's own error codes (which start at 777'000'000) so that a close code identifies
+    // unambiguously whether the tunnel or the QUIC layer ended the stream.
+    namespace tunnel_error
+    {
+        // The local TCP connection failed (as opposed to closing cleanly, which sends a FIN).
+        inline constexpr uint64_t TCP_FAILURE = 0x5471909;
+        // The accepting end could not establish a TCP connection to the requested port.
+        inline constexpr uint64_t CONNECT_FAILED = 0x5471907;
+        // The accepting end declined to connect to the requested port.
+        inline constexpr uint64_t REFUSED = 0x547190a;
+    }  // namespace tunnel_error
 
     struct TCPConnection
     {
@@ -42,57 +53,61 @@ namespace srouter
 
         std::shared_ptr<quic::Stream> stream;
 
-        std::vector<std::byte> pending_buffer;
+        // Invoked once, when both directions have finished or either end failed, to tell the owner
+        // to drop this connection.  This can fire from inside a bufferevent or stream callback, so
+        // the owner must defer the destruction rather than doing it during the call.
+        std::function<void()> on_done;
 
-        void on_stream_data(quic::Stream& stream, std::span<const std::byte> data);
-
+        // Ends the connection.  A zero code closes the stream cleanly; any other code is delivered
+        // to the far end to distinguish a failure from an orderly shutdown.
         void close(uint64_t ec = 0);
 
         void on_write_available();
 
         void stop_reading();
         void resume_reading();
+
+        // The local TCP side finished sending (a clean EOF); passes the half-close on to the far end
+        // and leaves the other direction running.
+        void on_tcp_eof();
+
+        // The far end finished sending; shuts down our write side once anything still buffered for
+        // the application has drained.
+        void on_stream_fin();
+
+        // False only between starting an outgoing connection and it completing, so that a failure
+        // during that window is reported as "could not connect" rather than "connection broke".
+        bool _connected{true};
+
+        bool _finished{false};
+        bool _fin_sent{false};
+        bool _fin_received{false};
+        bool _write_shutdown{false};
+
+        void finish();
+        void flush_and_shutdown_write();
     };
 
     using tcpconn_hook = std::function<TCPConnection*(bufferevent*, TCPConnection::fd_t)>;
 
     class TCPHandle
     {
-        using socket_t =
-#ifndef _WIN32
-            int
-#else
-            SOCKET
-#endif
-            ;
-
         quic::Loop& _ev;
         std::shared_ptr<::evconnlistener> _tcp_listener;
 
-        // The OutboundSession will set up an evconnlistener and set the listening socket address inside ::_bound
+        // The address the listener is bound to, filled in from the socket once it is listening.
         quic::Address _bound{};
 
-        // The InboundSession will set this address to the session-router-primary-ip to connect to
-        std::optional<quic::Address> _connect = std::nullopt;
-
-        socket_t _sock;
-
         explicit TCPHandle(quic::Loop& ev, tcpconn_hook cb, uint16_t p);
-
-        explicit TCPHandle(quic::Loop& ev, quic::Address connect);
 
       public:
         TCPHandle() = delete;
 
         tcpconn_hook _conn_maker;
 
-        // The OutboundSession object will hold a server listening on some localhost:port, returning that port to the
-        // application for it to make a TCP connection
+        // Listens on the IPv6 loopback address for the initiating side of a tunnel, returning the
+        // bound port for the application to connect to.  Port 0 (the default) takes any free port.
         static std::shared_ptr<TCPHandle> make_server(quic::Loop& ev, tcpconn_hook cb, uint16_t port = 0);
-
-        // The InboundSession object will hold a client that connects to some application configured
-        // session-router-primary-ip:port every time the OutboundSession opens a new stream over the tunneled connection
-        static std::shared_ptr<TCPHandle> make_client(quic::Loop& ev, quic::Address connect);
 
         ~TCPHandle();
 
@@ -100,12 +115,13 @@ namespace srouter
 
         const quic::Address& bind_address() const { return _bound; }
 
+        // Used by the accepting side of a tunnel: connects to `dest` and pairs the resulting socket
+        // with `s`.  The stream should be paused until the connection completes, which the returned
+        // connection signals by resuming it.  Returns nullptr if the connection could not be started.
         static std::shared_ptr<TCPConnection> connect(
-            event_base* _ev, quic::Address src, std::shared_ptr<quic::Stream> s, uint16_t port);
+            quic::Loop& ev, const quic::Address& dest, std::shared_ptr<quic::Stream> s);
 
       private:
-        void _init_client();
-
         void _init_server(uint16_t port);
     };
 }  //  namespace srouter

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1352,12 +1352,13 @@ namespace srouter::handlers
             }
 
             mapped_remote target{.remote = remote, .port = port};
-            auto& [udp_handle, cports, holders] = _udp_handles[target];
-            bool existing = static_cast<bool>(udp_handle);
-            holders++;
+            auto h_it = _udp_handles.find(target);
+            bool existing = h_it != _udp_handles.end();
             if (!existing)
-
-                udp_handle = std::make_unique<quic::UDPSocket>(
+            {
+                // Construct before inserting and counting: a throwing socket constructor would
+                // otherwise leave behind an entry with a holder that nothing can ever release.
+                auto socket = std::make_unique<quic::UDPSocket>(
                     router.loop().get_event_base(),
                     quic::Address{"::1", 0},
                     /*gso=*/false,
@@ -1434,7 +1435,12 @@ namespace srouter::handlers
                         session->send_session_data_message(packet, traffic_type::UDP);
                     });
 
-            local_port = udp_handle->address().port();
+                h_it = _udp_handles.try_emplace(target).first;
+                h_it->second.socket = std::move(socket);
+            }
+
+            h_it->second.holders++;
+            local_port = h_it->second.socket->address().port();
             log::debug(
                 logcat,
                 "{} mapped UDP port ({}) for remote {}:{}",

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -12,6 +12,7 @@
 #include "path/transit_hop.hpp"
 #include "router/router.hpp"
 #include "session/session.hpp"
+#include "session/tcp_tunnel.hpp"
 #include "util/bspan.hpp"
 #include "util/logging/buffer.hpp"
 #include "util/random.hpp"
@@ -1488,6 +1489,128 @@ namespace srouter::handlers
             _udp_handles.erase(it);
 
             log::debug(logcat, "Unmapped localhost:{} -> {}:{} UDP mapping", local_port, remote, port);
+        });
+    }
+
+    TCPConnection* SessionEndpoint::tunnel_tcp_connection(
+        const mapped_remote& target, bufferevent* bev, TCPConnection::fd_t fd)
+    {
+        std::shared_ptr<session::Session> session;
+        try
+        {
+            // As with UDP, re-obtaining the session per connection is what lets a mapping survive an
+            // idle timeout and re-establish itself on the next use.
+            session = initiate_remote_session(target.remote);
+        }
+        catch (const std::exception& e)
+        {
+            log::warning(
+                logcat, "Cannot obtain a session to {} for a tunnelled TCP connection: {}", target.remote, e.what());
+            return nullptr;
+        }
+
+        if (!session)
+        {
+            log::warning(logcat, "Dropping TCP connection for unreachable remote {}", target.remote);
+            return nullptr;
+        }
+
+        if (auto accepts = session->remote_accepts_tcp(); accepts.has_value() && !*accepts)
+        {
+            log::warning(logcat, "Dropping TCP connection: {} does not accept tunnelled TCP", target.remote);
+            return nullptr;
+        }
+
+        return session->tunnel().connect_stream(bev, fd, target.port);
+    }
+
+    std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> SessionEndpoint::map_tcp_remote_port(
+        const NetworkAddress& remote, uint16_t port)
+    {
+        return router._jq->call_get([&]() -> std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> {
+            std::pair<uint16_t, std::shared_ptr<session::Session>> result;
+            auto& [local_port, session] = result;
+
+            session = initiate_remote_session(remote);  // throws on immediate error
+            if (!session)
+            {
+                log::debug(logcat, "Not mapping a TCP port for {}: remote is unreachable", remote);
+                return std::nullopt;
+            }
+
+            // A remote we know cannot terminate a tunnelled stream gets refused now rather than at
+            // connection time.  Not knowing (no client contact yet) is not a refusal: we map, and
+            // find out when the contact arrives.
+            if (auto accepts = session->remote_accepts_tcp(); accepts.has_value() && !*accepts)
+            {
+                log::debug(logcat, "Not mapping a TCP port for {}: remote does not accept tunnelled TCP", remote);
+                return std::nullopt;
+            }
+
+            mapped_remote target{.remote = remote, .port = port};
+
+            auto it = _tcp_handles.find(target);
+            if (it == _tcp_handles.end())
+            {
+                std::shared_ptr<TCPHandle> listener;
+                try
+                {
+                    listener = TCPHandle::make_server(
+                        router.loop(), [this, target](bufferevent* bev, TCPConnection::fd_t fd) -> TCPConnection* {
+                            return tunnel_tcp_connection(target, bev, fd);
+                        });
+                }
+                catch (const std::exception& e)
+                {
+                    log::error(logcat, "Failed to bind a local TCP port for {}: {}", remote, e.what());
+                    return std::nullopt;
+                }
+
+                it = _tcp_handles.try_emplace(target).first;
+                it->second.listener = std::move(listener);
+            }
+
+            it->second.holders++;
+            local_port = it->second.listener->port();
+
+            log::debug(logcat, "Mapped TCP [::1]:{} -> {}:{}", local_port, remote, port);
+            return result;
+        });
+    }
+
+    void SessionEndpoint::unmap_tcp_remote_port(const NetworkAddress& remote, uint16_t port)
+    {
+        // As in map_tcp_remote_port: these containers belong to the job queue thread, and an
+        // embedded caller can be on any thread at all.
+        router._jq->call_get([&] {
+            auto it = _tcp_handles.find(mapped_remote{.remote = remote, .port = port});
+            if (it == _tcp_handles.end())
+            {
+                log::debug(logcat, "Nothing to unmap: {}:{} is not currently a mapped TCP port", remote, port);
+                return;
+            }
+
+            if (--it->second.holders > 0)
+            {
+                log::debug(
+                    logcat,
+                    "Released a claim on {}:{}; {} still held, keeping it mapped",
+                    remote,
+                    port,
+                    it->second.holders);
+                return;
+            }
+
+            auto local_port = it->second.listener->port();
+            _tcp_handles.erase(it);
+
+            // Releasing the last claim takes the mapping's connections with it: holding the claim is
+            // what keeps them alive, so there is nothing left to keep them for.
+            if (auto* session = get_session(remote))
+                if (auto* tunnel = session->maybe_tunnel())
+                    tunnel->close_connections_for(port);
+
+            log::debug(logcat, "Unmapped localhost:{} -> {}:{} TCP mapping", local_port, remote, port);
         });
     }
 

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -41,7 +41,7 @@ namespace srouter::handlers
 
             protocol_flag protocols = protocol_flag::PFS_PQ;
             if (!router.embedded())
-                protocols |= protocol_flag::IPV4 | protocol_flag::IPV6;
+                protocols |= protocol_flag::IPV4 | protocol_flag::IPV6 | protocol_flag::TCP_TUNNEL;
 
             client_contact.emplace(
                 router.key_manager.router_id(), netconf.srv_records, protocols, sys_ms{}, netconf.traffic_policy);

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -3,6 +3,7 @@
 #include "address/address.hpp"
 #include "config/config.hpp"
 #include "contact/client_contact.hpp"
+#include "ev/tcp.hpp"
 #include "path/path_handler.hpp"
 #include "path/transit_hop.hpp"
 #include "session/session.hpp"
@@ -146,6 +147,26 @@ namespace srouter
             // can safely ask for the same remote:port again and just get the existing one rather
             // than a new listening socket.
             std::unordered_map<mapped_remote, udp_handle, mapped_remote::hash> _udp_handles;
+
+            struct tcp_handle
+            {
+                std::shared_ptr<TCPHandle> listener;
+
+                // How many callers currently hold this mapping, exactly as for udp_handle: the
+                // mapping is torn down by the last holder to release it, not the first.
+                int holders = 0;
+            };
+
+            // Established embedded client TCP maps: {remote:port} -> listener.  The listener lives
+            // here rather than on the session because it has to outlive session churn: the tunnel
+            // beneath it can come and go (a dead path, an idle teardown, a session timing out)
+            // without the port the application was handed changing underneath it.
+            std::unordered_map<mapped_remote, tcp_handle, mapped_remote::hash> _tcp_handles;
+
+            // Pairs a newly accepted connection on a mapped local TCP port with a stream to the
+            // remote, obtaining (or re-establishing) the session as needed.  Returns nullptr if it
+            // cannot be tunnelled, in which case the local connection is dropped.
+            TCPConnection* tunnel_tcp_connection(const mapped_remote& target, bufferevent* bev, TCPConnection::fd_t fd);
 
             uint16_t _next_udp_client_port{0};
 
@@ -362,6 +383,31 @@ namespace srouter
             // Removes a mapping previously established with map_udp_remote_port; this closes the
             // socket and forgets any previous connection mappings.
             void unmap_udp_remote_port(const NetworkAddress& remote, uint16_t port);
+
+            // TCP port mapping, for embedded clients.  This is the TCP counterpart of
+            // map_udp_remote_port: it starts constructing a session to the given remote and listens
+            // on an IPv6 localhost (i.e. `[::1]`) random port, where each connection the application
+            // makes becomes one stream of a QUIC connection tunnelled through the session, and is
+            // terminated by the remote into a TCP connection to `port` on its own tun address.
+            //
+            // Returns the same pair as map_udp_remote_port: the local port to connect to, and the
+            // session (so a caller can hook its establishment).
+            //
+            // Returns nullopt, mapping nothing, if the remote is known to be unreachable, or if the
+            // remote's client contact says it does not accept tunnelled TCP: no session could carry
+            // what the port would receive.  A remote whose contact we do not have yet is *not*
+            // refused here, since we cannot yet tell.
+            //
+            // Throws (via initiate_remote_session) if the session could not be initiated, such as
+            // when given an invalid pubkey in `remote`.
+            std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> map_tcp_remote_port(
+                const NetworkAddress& remote, uint16_t port);
+
+            // Removes a mapping previously established with map_tcp_remote_port once its last
+            // holder releases it, closing both the listener and any connections established through
+            // it.  Not called directly by applications: the public API releases mappings by
+            // destroying the tcp_tunnel claim that holds them.
+            void unmap_tcp_remote_port(const NetworkAddress& remote, uint16_t port);
         };
 
     }  // namespace handlers

--- a/src/net/policy.cpp
+++ b/src/net/policy.cpp
@@ -16,8 +16,10 @@ namespace srouter
     std::string to_string(protocol_flag p)
     {
         auto has_flag = [&p](protocol_flag f) { return (p & f) == f; };
-        return "<host/{}ipv4/{}ipv6>"_format(
-            has_flag(protocol_flag::IPV4) ? "" : "no-", has_flag(protocol_flag::IPV6) ? "" : "no-");
+        return "<host/{}ipv4/{}ipv6/{}tcp-tunnel>"_format(
+            has_flag(protocol_flag::IPV4) ? "" : "no-",
+            has_flag(protocol_flag::IPV6) ? "" : "no-",
+            has_flag(protocol_flag::TCP_TUNNEL) ? "" : "no-");
     }
     namespace net
     {

--- a/src/net/policy.hpp
+++ b/src/net/policy.hpp
@@ -15,12 +15,23 @@ namespace srouter
         NONE = 0,
         // 1 << 0,  // Not currently used.
         // 1 << 1,  // Not currently used.
-        IPV4 = 1 << 2,    // This client support Session Router raw IPv4 packets (currently always
-                          // set for non-embedded clients)
-        IPV6 = 1 << 3,    // This client support Session Router raw IPv6 packets (currently always
-                          // set for non-embedded clients)
-        PFS_PQ = 1 << 4,  // This client supports PFS+PQ session initiation.  This flag will be
-                          // dropped in the future, once 1.0.x Session Router support is dropped.
+        IPV4 = 1 << 2,        // This client support Session Router raw IPv4 packets (currently always
+                              // set for non-embedded clients)
+        IPV6 = 1 << 3,        // This client support Session Router raw IPv6 packets (currently always
+                              // set for non-embedded clients)
+        PFS_PQ = 1 << 4,      // This client supports PFS+PQ session initiation.  This flag will be
+                              // dropped in the future, once 1.0.x Session Router support is dropped.
+        TCP_TUNNEL = 1 << 5,  // This client accepts tunnelled TCP connections, i.e. it can terminate
+                              // a tunnelled stream into a local TCP connection.  Set only by clients
+                              // with a tun device; an initiator without this flag on the remote
+                              // should not bother trying.
+                              //
+                              // NB: this is deliberately a new bit rather than 1.0.x's QUIC_TUNNEL
+                              // (1 << 1), which advertised the opposite role: it meant "I am
+                              // embedded, so reach me via a tunnel", and was set by clients that
+                              // cannot accept one.  Redefining it would make every 1.0.x embedded
+                              // client look like an acceptor.  Bit 0 (1.0.x EXIT) is likewise in use
+                              // in the wild.
     };
     inline constexpr protocol_flag operator&(protocol_flag a, protocol_flag b)
     {

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1,6 +1,7 @@
 #include "session.hpp"
 
 #include "crypto/crypto.hpp"
+#include "tcp_tunnel.hpp"
 #include "handlers/session.hpp"
 #include "handlers/tun.hpp"
 #include "link/endpoint.hpp"
@@ -29,249 +30,11 @@
 #include <random>
 #include <utility>
 
-namespace
-{
-    using namespace oxenc::literals;
-    // GNUTLS Creds tunnel default keys until we implement null-crypto in libquic
-    inline constexpr auto TUNNEL_SEED = "0000000000000000000000000000000000000000000000000000000000000000"_hex;
-    inline constexpr auto TUNNEL_PUBKEY = "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"_hex;
-}  // anonymous namespace
-
 namespace srouter::session
 {
     namespace quic = oxen::quic;
 
     static auto logcat = log::Cat("session");
-    struct TCPTunnel
-    {
-        const quic::Address FAKE_QUIC_ADDR{"127.86.75.30"s, 9};
-        const quic::Path FAKE_QUIC_PATH{FAKE_QUIC_ADDR, FAKE_QUIC_ADDR};
-
-        std::shared_ptr<quic::GNUTLSCreds> tls_creds = quic::GNUTLSCreds::make_from_ed_keys(TUNNEL_SEED, TUNNEL_PUBKEY);
-
-        std::shared_ptr<quic::Endpoint> quic_ep{nullptr};
-        std::shared_ptr<quic::Connection> quic_conn{nullptr};
-
-        // (session initiator) TCPHandle listeners mapped to the destination port they are mapped for
-        std::unordered_map<uint16_t, std::shared_ptr<TCPHandle>> tcp_handles;
-
-        // (session remote) QUIC stream ID to TCP connection
-        std::vector<std::shared_ptr<TCPConnection>> _tcp_conns;
-
-        Session& session;
-
-        std::shared_ptr<bool> destructor_canary{std::make_shared<bool>(true)};
-
-        ~TCPTunnel() { reset(); }
-
-        // the QUIC endpoint should be fine if the QUIC connection closes, but
-        // TCP conns and port mappings will need to be restarted.
-        void reset()
-        {
-            log::trace(logcat, "TCPTunnel::reset()");
-            quic_conn.reset();
-            _tcp_conns.clear();
-            tcp_handles.clear();
-            log::trace(logcat, "TCPTunnel::reset() END");
-        }
-
-        TCPTunnel(Session& _session) : session(_session)
-        {
-            quic::opt::manual_routing quic_send{[this](const quic::Path&, std::span<const std::byte> data) {
-                session.send_session_data_message(data, traffic_type::TUNNELED_QUIC);
-            }};
-            quic::connection_established_callback new_conn{[this](quic::Connection& conn) {
-                if (quic_conn)
-                {
-                    log::error(logcat, "Already have connection for QUIC tunnel for session to {}!", session._remote);
-                    return;
-                }
-                log::debug(logcat, "New connection for QUIC tunnel for session to {}!", session._remote);
-                quic_conn = conn.shared_from_this();
-            }};
-            quic::connection_closed_callback conn_closed{
-                [this, canary = std::weak_ptr{destructor_canary}](quic::Connection&, uint64_t) {
-                    if (!quic_conn)
-                    {
-                        log::warning(
-                            logcat,
-                            "Received conn closed, but this session's QUIC tunnel does not seem to have an open "
-                            "connection, remote: {}",
-                            session._remote);
-                        return;
-                    }
-                    log::debug(logcat, "QUIC TCP tunnel conn to {} closed.", session._remote);
-
-                    // this could fire from quic::Endpoint destructor, at which point
-                    // the members `reset` would reset may no longer be valid objects
-                    if (canary.lock())
-                        reset();
-                }};
-
-            auto stream_opened = [this](quic::Stream& stream) {
-#if 0
-                stream.set_stream_data_cb([this, prev_byte = std::optional<std::byte>{std::nullopt}](
-                                              quic::Stream& stream, std::span<const std::byte> data) mutable {
-                    uint16_t dest_port{0};
-
-                                        if (data.empty())
-                                        {
-                                            log::error(logcat, "QUIC stream data callback with no data!");
-                                            return;
-                                        }
-                                        if (prev_byte)
-                                        {
-                                            std::array<std::byte, 2> buf;
-                                            buf[0] = *prev_byte;
-                                            buf[1] = data[0];
-                                            dest_port = oxenc::load_big_to_host<uint16_t>(buf.data());
-                                            data = data.subspan(1);
-                                        }
-                                        else if (data.size() >= 2)
-                                        {
-                                            dest_port = oxenc::load_big_to_host<uint16_t>(data.data());
-                                            data = data.subspan(2);
-                                        }
-                                        else
-                                        {  // only got 1 byte total so far, need 2 for dest port
-                                            prev_byte = data[0];
-                                            return;
-                                        }
-
-                                        stream.pause();
-
-                                        // FIXME: TCPHandle::connect replaces the stream's data callback.  Perhaps
-                                        // that should happen here instead.
-                                        // FIXME: the connection should probably come from tun bind address, if
-                                        // available, rather than always 127.0.0.1
-                                        auto tcp_conn = TCPHandle::connect(
-                                            session._r.loop.get_event_base(), FAKE_QUIC_ADDR, stream.shared_from_this(),
-                       dest_port); if (!tcp_conn)
-                                        {
-                                            stream.close(11223322);  // TODO: meaningful error code
-                                            return;
-                                        }
-
-                                        _tcp_conns.push_back(tcp_conn);
-
-                                        if (data.size())
-                                        {
-                                            // put any remaining stream data on the tcp socket
-                                            stream.data_callback(stream, data);
-                                        }
-
-                                        stream.enable_watermarks(
-                                            500'000,
-                                            [this, tcp_conn](auto&) { tcp_conn->stop_reading(); },
-                                            50'000,
-                                            [this, tcp_conn](auto&) { tcp_conn->resume_reading(); });
-                });
-#endif
-                return 0;
-            };
-
-            quic_ep = quic::Endpoint::endpoint(
-                // TODO FIXME: this should probably attach to the network loop rather than the logic loop:
-                // TODO FIXME: this is now further weird with the separate JobQueue change to libquic
-                session._r.loop(),
-                FAKE_QUIC_ADDR,
-                std::move(quic_send),
-                std::move(new_conn),
-                std::move(conn_closed),
-                quic::opt::disable_mtu_discovery{});
-
-            // TODO: only listen if we support inbound tunneled traffic
-            quic_ep->listen(tls_creds, std::move(stream_opened));
-        }
-
-        void open_connection()
-        {
-            if (quic_conn)
-            {
-                log::error(
-                    logcat, "Cannot create more than one QUIC connection over TPC tunnel, remote: {}", session._remote);
-                return;
-            }
-
-            quic_conn = quic_ep->connect(
-                quic::RemoteAddress{TUNNEL_PUBKEY, FAKE_QUIC_ADDR},
-                tls_creds,
-                [this](quic::Connection& conn) {
-                    log::debug(logcat, "Outbound QUIC TCP Tunnel connection established to {}", session._remote);
-                    if (!quic_conn)
-                    {
-                        quic_conn = conn.shared_from_this();
-                    }
-                },  // connection established
-                [this, canary = std::weak_ptr{destructor_canary}](quic::Connection&, uint64_t) /* connection closed*/ {
-                    // this could fire from quic::Endpoint destructor, at which point
-                    // the members referenced below may no longer be valid objects
-                    if (!canary.lock())
-                        return;
-                    if (!quic_conn)
-                        log::error(logcat, "QUIC TPC tunnel connection to {} failed!", session._remote);
-                    else
-                        log::debug(logcat, "QUIC TPC tunnel connection to {} closed.", session._remote);
-                    reset();
-                });
-        }
-
-        uint16_t map_tcp_remote_port(uint16_t dest_port)
-        {
-            if (!session.is_established())
-                return 0;
-            if (!quic_conn)
-            {
-                open_connection();
-            }
-
-            auto _handle = TCPHandle::make_server(
-                // TODO FIXME: this should probably attach to the network loop rather than the logic loop:
-                // TODO FIXME: this is now further weird with the separate JobQueue change to libquic
-                session._r.loop(),
-                [this, dest_port](struct bufferevent* _bev, evutil_socket_t _fd) -> TCPConnection* {
-                    auto s =
-                        quic_conn->open_stream<quic::Stream>([_bev](quic::Stream& s, std::span<const std::byte> data) {
-                            auto rv = bufferevent_write(_bev, data.data(), data.size());
-
-                            log::debug(
-                                logcat,
-                                "Stream (id:{}) {} {}B to TCP buffer",
-                                s.stream_id(),
-                                rv < 0 ? "failed to write" : "successfully wrote",
-                                data.size());
-                        });
-                    if (!s)
-                    {
-                        log::error(logcat, "Failed to open stream for TCP tunnel...");
-                        return nullptr;
-                    }
-                    std::string p;
-                    p.resize(2);
-                    oxenc::write_host_as_big(dest_port, p.data());
-                    s->send(std::move(p));
-
-                    auto tcp_conn = std::make_shared<TCPConnection>(_bev, _fd, std::move(s));
-
-                    auto* ptr = tcp_conn.get();
-                    _tcp_conns.push_back(std::move(tcp_conn));
-
-                    return ptr;
-                });
-
-            auto bound_port = _handle->port();
-            if (bound_port == 0)
-            {
-                log::error(logcat, "Failed to bind TCP port for tunneled session.");
-                return 0;
-            }
-
-            log::debug(logcat, "Bound TCP tunneled session, dest_port: {}, local_port: {}", dest_port, bound_port);
-            tcp_handles.emplace(dest_port, std::move(_handle));
-            return bound_port;
-        }
-    };
-
     void InboundSession::init(std::span<const std::byte> request)
     {
         oxenc::bt_dict_consumer outer_btdc{request};
@@ -410,10 +173,7 @@ namespace srouter::session
           _remote{remote},
           is_outbound{true},
           is_relay_session{_remote.relay()}
-    {
-        // Maybe we should make this on demand rather than on construction?
-        tcp_tunnel = std::make_unique<TCPTunnel>(*this);
-    }
+    {}
 
     Session::Session(Router& r, handlers::SessionEndpoint& parent)
         : _r{r},
@@ -421,9 +181,13 @@ namespace srouter::session
           _is_established{true},  // Inbound sessions are established from construction
           is_outbound{false},
           is_relay_session{_r.is_service_node}
+    {}
+
+    TCPTunnel& Session::tunnel()
     {
-        // Maybe we should make this on demand rather than on construction?
-        tcp_tunnel = std::make_unique<TCPTunnel>(*this);
+        if (!tcp_tunnel)
+            tcp_tunnel = std::make_unique<TCPTunnel>(*this);
+        return *tcp_tunnel;
     }
 
     Session::~Session()
@@ -825,8 +589,7 @@ namespace srouter::session
                 log::warning(logcat, "Received non-UDP, non-tunneled datagram on embedded client, dropping!");
             }
             else
-                tcp_tunnel->quic_ep->manually_receive_packet(
-                    oxen::quic::Packet{tcp_tunnel->FAKE_QUIC_PATH, std::move(data)});
+                tunnel().receive_packet(std::move(data));
             return;
         }
 
@@ -835,8 +598,7 @@ namespace srouter::session
         // remotes (which also send raw UDP packets):
         if (dgram_type == traffic_type::TUNNELED_QUIC)
         {
-            tcp_tunnel->quic_ep->manually_receive_packet(
-                oxen::quic::Packet{tcp_tunnel->FAKE_QUIC_PATH, std::move(data)});
+            tunnel().receive_packet(std::move(data));
             return;
         }
 
@@ -941,8 +703,6 @@ namespace srouter::session
         log::trace(
             logcat, "UDP from remote -> socket send to local returned {} (ec={})", ior.success(), ior.error_code);
     }
-
-    uint16_t Session::map_tcp_remote_port(uint16_t dest_port) { return tcp_tunnel->map_tcp_remote_port(dest_port); }
 
     bool Session::is_established() const { return _is_established && !_is_closed; }
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1,7 +1,6 @@
 #include "session.hpp"
 
 #include "crypto/crypto.hpp"
-#include "tcp_tunnel.hpp"
 #include "handlers/session.hpp"
 #include "handlers/tun.hpp"
 #include "link/endpoint.hpp"
@@ -10,6 +9,7 @@
 #include "path/path.hpp"
 #include "path/transit_hop.hpp"
 #include "router/router.hpp"
+#include "tcp_tunnel.hpp"
 #include "util/bspan.hpp"
 #include "util/formattable.hpp"
 #include "util/random.hpp"
@@ -1552,6 +1552,14 @@ namespace srouter::session
     }
 
     bool OutboundClientSession::use_old_init() const { return not has_flag(_cc_protos, protocol_flag::PFS_PQ); }
+
+    std::optional<bool> OutboundClientSession::remote_accepts_tcp() const
+    {
+        // NONE means no client contact has arrived yet, rather than a remote that supports nothing.
+        if (_cc_protos == protocol_flag::NONE)
+            return std::nullopt;
+        return has_flag(_cc_protos, protocol_flag::TCP_TUNNEL);
+    }
 
     bool OutboundRelaySession::use_old_init() const
     {

--- a/src/session/session.hpp
+++ b/src/session/session.hpp
@@ -331,6 +331,11 @@ namespace srouter
             // The TCP tunnel if this session has one, without creating one.
             TCPTunnel* maybe_tunnel() { return tcp_tunnel.get(); }
 
+            // Whether the remote advertises that it can terminate tunnelled TCP streams.  nullopt
+            // means we have no client contact for the remote yet and so cannot tell, in which case a
+            // caller may go ahead and find out the hard way.
+            virtual std::optional<bool> remote_accepts_tcp() const { return std::nullopt; }
+
             // Returns true if this session is established, and has not been explicitly closed.
             // Inbound sessions are instantly established; outbound sessions are established once
             // the session init response arrives from the remote.
@@ -548,6 +553,7 @@ namespace srouter
 
             void select_new_current() override;
             bool use_old_init() const override;
+            std::optional<bool> remote_accepts_tcp() const override;
 
           protected:
             void handle_client_contact(std::span<const std::byte> payload) override;

--- a/src/session/session.hpp
+++ b/src/session/session.hpp
@@ -324,9 +324,12 @@ namespace srouter
 
             void handle_udp_from_remote(IPPacket&& pkt);
 
-            uint16_t setup_udp_mapping(uint16_t dest_port);
+            // Returns this session's TCP tunnel, constructing it on first use: most sessions never
+            // carry tunnelled TCP and should not pay for a QUIC endpoint they will not use.
+            TCPTunnel& tunnel();
 
-            uint16_t map_tcp_remote_port(uint16_t dest_port);
+            // The TCP tunnel if this session has one, without creating one.
+            TCPTunnel* maybe_tunnel() { return tcp_tunnel.get(); }
 
             // Returns true if this session is established, and has not been explicitly closed.
             // Inbound sessions are instantly established; outbound sessions are established once

--- a/src/session/tcp_tunnel.cpp
+++ b/src/session/tcp_tunnel.cpp
@@ -8,19 +8,9 @@
 
 #include <event2/bufferevent.h>
 #include <oxen/quic/opt.hpp>
+#include <oxen/quic/unencrypted.hpp>
 #include <oxenc/endian.h>
 #include <oxenc/hex.h>
-
-namespace
-{
-    using namespace oxenc::literals;
-
-    // A fixed, well-known keypair stands in for credentials the inner connection does not actually
-    // need: it carries nothing the session layer has not already encrypted end to end.  This goes
-    // away once libquic can do null crypto, which also removes the handshake these force us into.
-    inline constexpr auto TUNNEL_SEED = "0000000000000000000000000000000000000000000000000000000000000000"_hex;
-    inline constexpr auto TUNNEL_PUBKEY = "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"_hex;
-}  // namespace
 
 namespace srouter::session
 {
@@ -48,7 +38,10 @@ namespace srouter::session
 
     TCPTunnel::TCPTunnel(Session& session) : _session{session}
     {
-        _tls_creds = quic::GNUTLSCreds::make_from_ed_keys(TUNNEL_SEED, TUNNEL_PUBKEY);
+        // The inner connection carries nothing that the session layer has not already encrypted end
+        // to end and the path layer onion-encrypted, and its peer is authenticated by the session
+        // itself, so QUIC's own crypto here would only buy a second AEAD pass and a handshake.
+        _tls_creds = quic::DangerouslyUnencryptedCreds::i_know_this_traffic_is_already_encrypted();
 
         quic::opt::manual_routing send_hook{[this](const quic::Path&, std::span<const std::byte> data) {
             _session.send_session_data_message(data, traffic_type::TUNNELED_QUIC);
@@ -120,7 +113,9 @@ namespace srouter::session
         log::debug(logcat, "Opening QUIC tunnel connection for session to {}", _session._remote);
 
         _conn = _ep->connect(
-            quic::RemoteAddress{TUNNEL_PUBKEY, FAKE_QUIC_ADDR},
+            // No remote key to verify: nothing here authenticates anything, and the session this
+            // rides inside has already authenticated the peer.
+            quic::RemoteAddress{""sv, FAKE_QUIC_ADDR},
             _tls_creds,
             quic::opt::max_streams{INNER_MAX_STREAMS},
             quic::opt::idle_timeout{INNER_IDLE_TIMEOUT},
@@ -153,7 +148,11 @@ namespace srouter::session
         adopt(std::move(conn), dest_port);
 
         log::debug(
-            logcat, "Tunnelling TCP connection to {}:{} over stream {}", _session._remote, dest_port, stream->stream_id());
+            logcat,
+            "Tunnelling TCP connection to {}:{} over stream {}",
+            _session._remote,
+            dest_port,
+            stream->stream_id());
 
         return ptr;
     }
@@ -191,8 +190,7 @@ namespace srouter::session
         return 0;
     }
 
-    void TCPTunnel::start_accepted_stream(
-        std::shared_ptr<quic::Stream> stream, std::shared_ptr<pending_stream> pending)
+    void TCPTunnel::start_accepted_stream(std::shared_ptr<quic::Stream> stream, std::shared_ptr<pending_stream> pending)
     {
         auto dest_port = oxenc::load_big_to_host<uint16_t>(pending->buffered.data());
         if (dest_port == 0)

--- a/src/session/tcp_tunnel.cpp
+++ b/src/session/tcp_tunnel.cpp
@@ -1,0 +1,321 @@
+#include "tcp_tunnel.hpp"
+
+#include "handlers/tun_interface.hpp"
+#include "net/traffic_type.hpp"
+#include "router/router.hpp"
+#include "session.hpp"
+#include "util/logging.hpp"
+
+#include <event2/bufferevent.h>
+#include <oxen/quic/opt.hpp>
+#include <oxenc/endian.h>
+#include <oxenc/hex.h>
+
+namespace
+{
+    using namespace oxenc::literals;
+
+    // A fixed, well-known keypair stands in for credentials the inner connection does not actually
+    // need: it carries nothing the session layer has not already encrypted end to end.  This goes
+    // away once libquic can do null crypto, which also removes the handshake these force us into.
+    inline constexpr auto TUNNEL_SEED = "0000000000000000000000000000000000000000000000000000000000000000"_hex;
+    inline constexpr auto TUNNEL_PUBKEY = "3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"_hex;
+}  // namespace
+
+namespace srouter::session
+{
+    static auto logcat = log::Cat("tcp");
+
+    // The inner connection never touches a real socket, so its addresses are arbitrary; they exist
+    // only because ngtcp2 requires a path.
+    static const quic::Address FAKE_QUIC_ADDR{"127.86.75.30"s, 9};
+    static const quic::Path FAKE_QUIC_PATH{FAKE_QUIC_ADDR, FAKE_QUIC_ADDR};
+
+    // Each TCP connection takes a stream, so the default (32) is far too few for something like a
+    // browser.
+    inline constexpr uint64_t INNER_MAX_STREAMS = 256;
+
+    // QUIC closes a connection with no activity *at all* on it, which would kill a TCP connection
+    // that is merely idle (an ssh session, a long poll), so we ping to hold it open.  We only pay
+    // for that while connections exist: an inner connection with no streams left is torn down after
+    // INNER_IDLE_TEARDOWN, making a dormant tunnel free.
+    inline constexpr auto INNER_IDLE_TIMEOUT = 5min;
+    inline constexpr auto INNER_KEEP_ALIVE = 30s;
+    inline constexpr auto INNER_IDLE_TEARDOWN = 60s;
+
+    // The destination port sent as the first bytes of each stream.
+    inline constexpr size_t PORT_PREAMBLE_SIZE = 2;
+
+    TCPTunnel::TCPTunnel(Session& session) : _session{session}
+    {
+        _tls_creds = quic::GNUTLSCreds::make_from_ed_keys(TUNNEL_SEED, TUNNEL_PUBKEY);
+
+        quic::opt::manual_routing send_hook{[this](const quic::Path&, std::span<const std::byte> data) {
+            _session.send_session_data_message(data, traffic_type::TUNNELED_QUIC);
+        }};
+
+        quic::connection_established_callback on_established{[this](quic::Connection& conn) {
+            // Outbound connections are already recorded by open_connection(), so seeing ourselves
+            // here is normal; a *different* connection means the far end opened a second one.
+            if (_conn)
+            {
+                if (_conn.get() != &conn)
+                    log::error(logcat, "Already have a QUIC tunnel connection for session to {}!", _session._remote);
+                return;
+            }
+            log::debug(logcat, "QUIC tunnel connection for session to {} established", _session._remote);
+            _conn = conn.shared_from_this();
+        }};
+
+        quic::connection_closed_callback on_closed{
+            [this, alive = std::weak_ptr{_alive}](quic::Connection&, uint64_t ec) {
+                // This can fire from the Endpoint destructor, at which point our members are gone.
+                if (!alive.lock())
+                    return;
+                log::debug(logcat, "QUIC tunnel connection for session to {} closed ({})", _session._remote, ec);
+                reset();
+            }};
+
+        _ep = quic::Endpoint::endpoint(
+            _session._r.loop(),
+            FAKE_QUIC_ADDR,
+            std::move(send_hook),
+            std::move(on_established),
+            std::move(on_closed),
+            // TODO: drop to the single-datagram budget (1076) once libquic allows a sub-1200 cap on
+            // manually routed endpoints; at 1200 an inner packet needs an outer payload of 1324 to
+            // avoid being split across two path datagrams.
+            quic::opt::max_udp_payload::minimum());
+
+        // Only a client with a tun device can terminate an inbound stream into a local TCP
+        // connection, so only such a client accepts them.
+        // These have to match what open_connection() sets: the stream limit each side advertises is
+        // what caps the *other* side, and the idle timeout in force is the lower of the two, so
+        // leaving the accepting side at the defaults would cap streams at 32 and expire the
+        // connection after 30s -- killing connections that are merely idle.
+        if (_session._r.tun_endpoint())
+            _ep->listen(
+                _tls_creds,
+                quic::opt::max_streams{INNER_MAX_STREAMS},
+                quic::opt::idle_timeout{INNER_IDLE_TIMEOUT},
+                [this](quic::Stream& s) { return on_stream_opened(s); });
+    }
+
+    TCPTunnel::~TCPTunnel()
+    {
+        log::trace(logcat, "Tearing down TCP tunnel for session to {}", _session._remote);
+        _conns.clear();
+    }
+
+    void TCPTunnel::receive_packet(std::vector<std::byte>&& data)
+    {
+        _ep->manually_receive_packet(quic::Packet{FAKE_QUIC_PATH, std::move(data)});
+    }
+
+    void TCPTunnel::open_connection()
+    {
+        if (_conn)
+            return;
+
+        log::debug(logcat, "Opening QUIC tunnel connection for session to {}", _session._remote);
+
+        _conn = _ep->connect(
+            quic::RemoteAddress{TUNNEL_PUBKEY, FAKE_QUIC_ADDR},
+            _tls_creds,
+            quic::opt::max_streams{INNER_MAX_STREAMS},
+            quic::opt::idle_timeout{INNER_IDLE_TIMEOUT},
+            quic::opt::keep_alive{INNER_KEEP_ALIVE});
+    }
+
+    TCPConnection* TCPTunnel::connect_stream(bufferevent* bev, TCPConnection::fd_t fd, uint16_t dest_port)
+    {
+        open_connection();
+        if (!_conn)
+        {
+            log::warning(logcat, "No QUIC tunnel connection to {}; cannot tunnel TCP connection", _session._remote);
+            return nullptr;
+        }
+
+        auto stream = _conn->open_stream<quic::Stream>();
+        if (!stream)
+        {
+            log::warning(logcat, "Failed to open a tunnel stream to {}", _session._remote);
+            return nullptr;
+        }
+
+        std::string preamble;
+        preamble.resize(PORT_PREAMBLE_SIZE);
+        oxenc::write_host_as_big(dest_port, preamble.data());
+        stream->send(std::move(preamble));
+
+        auto conn = std::make_shared<TCPConnection>(bev, fd, stream);
+        auto* ptr = conn.get();
+        adopt(std::move(conn), dest_port);
+
+        log::debug(
+            logcat, "Tunnelling TCP connection to {}:{} over stream {}", _session._remote, dest_port, stream->stream_id());
+
+        return ptr;
+    }
+
+    uint64_t TCPTunnel::on_stream_opened(quic::Stream& stream)
+    {
+        // Hold the stream until we know where it is going and have a socket for it.  The pause only
+        // stops the window from being extended, so the port preamble still arrives.
+        stream.pause();
+
+        auto pending = std::make_shared<pending_stream>();
+
+        stream.set_data_callback(
+            [this, pending, alive = std::weak_ptr{_alive}](quic::Stream& s, std::span<const std::byte> data) {
+                if (!alive.lock())
+                    return;
+
+                pending->buffered.insert(pending->buffered.end(), data.begin(), data.end());
+
+                if (pending->connecting || pending->buffered.size() < PORT_PREAMBLE_SIZE)
+                    return;
+                pending->connecting = true;
+
+                // Handing the stream to a TCPConnection replaces this very callback, which cannot be
+                // done from inside it, so the connect happens on the next loop iteration.  Anything
+                // that arrives in the meantime keeps accumulating in `pending`.
+                _session._r.loop().call_soon(
+                    [this, pending, stream = s.shared_from_this(), alive = std::move(alive)]() mutable {
+                        if (!alive.lock())
+                            return;
+                        start_accepted_stream(std::move(stream), std::move(pending));
+                    });
+            });
+
+        return 0;
+    }
+
+    void TCPTunnel::start_accepted_stream(
+        std::shared_ptr<quic::Stream> stream, std::shared_ptr<pending_stream> pending)
+    {
+        auto dest_port = oxenc::load_big_to_host<uint16_t>(pending->buffered.data());
+        if (dest_port == 0)
+        {
+            log::warning(logcat, "Refusing tunnelled stream {}: port 0 is not a destination", stream->stream_id());
+            stream->close(tunnel_error::REFUSED);
+            return;
+        }
+
+        auto target = accept_target(dest_port);
+        if (!target)
+        {
+            log::warning(logcat, "Refusing tunnelled connection to port {}: no tun device to serve it", dest_port);
+            stream->close(tunnel_error::REFUSED);
+            return;
+        }
+
+        log::debug(logcat, "Tunnelled stream {} from {} wants {}", stream->stream_id(), _session._remote, *target);
+
+        auto stream_id = stream->stream_id();
+        auto conn = TCPHandle::connect(_session._r.loop(), *target, std::move(stream));
+        if (!conn)
+        {
+            log::warning(logcat, "Could not connect to {} for tunnelled stream {}", *target, stream_id);
+            return;
+        }
+
+        // Whatever arrived while we were setting up has to go out ahead of anything the socket
+        // subsequently carries.
+        if (auto rest = std::span{pending->buffered}.subspan(PORT_PREAMBLE_SIZE); !rest.empty())
+            bufferevent_write(conn->bev, rest.data(), rest.size());
+
+        // An accepted stream belongs to no local mapping, so it carries no mapped port.
+        adopt(std::move(conn), 0);
+    }
+
+    void TCPTunnel::adopt(std::shared_ptr<TCPConnection> conn, uint16_t mapped_port)
+    {
+        auto conn_id = _next_conn_id++;
+
+        conn->on_done = [this, conn_id, alive = std::weak_ptr{_alive}]() {
+            if (!alive.lock())
+                return;
+            drop(conn_id);
+        };
+
+        _conns[conn_id] = live_conn{.conn = std::move(conn), .mapped_port = mapped_port};
+    }
+
+    void TCPTunnel::close_connections_for(uint16_t dest_port)
+    {
+        for (auto& [stream_id, live] : _conns)
+        {
+            if (live.mapped_port != dest_port)
+                continue;
+
+            log::debug(logcat, "Closing tunnelled connection on stream {}: its mapping was released", stream_id);
+            live.conn->close();
+        }
+    }
+
+    void TCPTunnel::drop(uint64_t conn_id)
+    {
+        // This runs from inside a bufferevent or stream callback belonging to the connection we are
+        // dropping, so its destruction has to wait until we are out of it.
+        _session._r.loop().call_soon([this, conn_id, alive = std::weak_ptr{_alive}]() {
+            if (!alive.lock())
+                return;
+
+            _conns.erase(conn_id);
+            log::debug(logcat, "Tunnelled connection {} finished; {} left", conn_id, _conns.size());
+
+            if (_conns.empty())
+                schedule_idle_teardown();
+        });
+    }
+
+    void TCPTunnel::schedule_idle_teardown()
+    {
+        if (_idle_teardown_scheduled)
+            return;
+        _idle_teardown_scheduled = true;
+
+        _session._r.loop().call_later(INNER_IDLE_TEARDOWN, [this, alive = std::weak_ptr{_alive}]() {
+            if (!alive.lock())
+                return;
+            _idle_teardown_scheduled = false;
+
+            // Something started using it again while we were waiting; a later drop re-schedules.
+            if (!_conns.empty())
+                return;
+
+            if (_conn)
+            {
+                log::debug(logcat, "Closing idle QUIC tunnel connection to {}", _session._remote);
+                _conn->close_connection();
+                _conn.reset();
+            }
+        });
+    }
+
+    void TCPTunnel::reset()
+    {
+        log::trace(logcat, "Resetting TCP tunnel for session to {}", _session._remote);
+        _conn.reset();
+        _conns.clear();
+    }
+
+    std::optional<quic::Address> TCPTunnel::accept_target(uint16_t port) const
+    {
+        const auto& tun = _session._r.tun_endpoint();
+        if (!tun)
+            return std::nullopt;
+
+        // IPv6 only: it is always active on a tun client, and IPv4 is on its way out.
+        auto v6 = tun->get_ipv6_network().ip;
+        if (v6 == quic::ipv6{})
+        {
+            log::warning(logcat, "Cannot accept tunnelled TCP: tun device has no IPv6 address");
+            return std::nullopt;
+        }
+
+        return quic::Address{v6, port};
+    }
+
+}  // namespace srouter::session

--- a/src/session/tcp_tunnel.hpp
+++ b/src/session/tcp_tunnel.hpp
@@ -4,8 +4,8 @@
 
 #include <oxen/quic/address.hpp>
 #include <oxen/quic/connection.hpp>
+#include <oxen/quic/crypto.hpp>
 #include <oxen/quic/endpoint.hpp>
-#include <oxen/quic/gnutls_crypto.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -72,7 +72,7 @@ namespace srouter::session
 
         Session& _session;
 
-        std::shared_ptr<quic::GNUTLSCreds> _tls_creds;
+        std::shared_ptr<quic::TLSCreds> _tls_creds;
         std::shared_ptr<quic::Endpoint> _ep;
         std::shared_ptr<quic::Connection> _conn;
 

--- a/src/session/tcp_tunnel.hpp
+++ b/src/session/tcp_tunnel.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "ev/tcp.hpp"
+
+#include <oxen/quic/address.hpp>
+#include <oxen/quic/connection.hpp>
+#include <oxen/quic/endpoint.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace srouter::session
+{
+    namespace quic = oxen::quic;
+
+    class Session;
+
+    // Carries TCP connections over a session as streams of a QUIC connection nested inside the
+    // session's data channel.  Session data is deliberately unreliable, so it is this inner
+    // connection that supplies retransmission, ordering, flow control and congestion control; each
+    // TCP connection becomes one stream, prefixed with the port it wants on the far end.
+    //
+    // The initiating side is a client mapping a remote port for a local application; the accepting
+    // side is a client with a tun device, which terminates each stream into a TCP connection to its
+    // own tun address.  A client without a tun device never accepts, and so never listens.
+    struct TCPTunnel
+    {
+        explicit TCPTunnel(Session& session);
+        ~TCPTunnel();
+
+        TCPTunnel(const TCPTunnel&) = delete;
+        TCPTunnel& operator=(const TCPTunnel&) = delete;
+
+        // Feeds an inbound tunnelled packet from the session into the inner QUIC endpoint.
+        void receive_packet(std::vector<std::byte>&& data);
+
+        // Initiating side: pairs a newly accepted local TCP connection with a new stream requesting
+        // `dest_port` on the far end.  Returns nullptr if no stream could be opened, in which case
+        // the caller must drop the socket.
+        TCPConnection* connect_stream(bufferevent* bev, TCPConnection::fd_t fd, uint16_t dest_port);
+
+        // Drops the inner connection and every TCP connection riding on it; a later connect_stream()
+        // builds a new one.  Listeners are owned elsewhere and deliberately outlive this.
+        void reset();
+
+        // Closes every connection this tunnel is carrying for the given remote port, used when the
+        // last claim on that mapping goes away: releasing a mapping takes its connections with it.
+        void close_connections_for(uint16_t dest_port);
+
+      private:
+        // Stream data that arrived before the local TCP connection for it existed, along with the
+        // destination port preamble that precedes it.
+        struct pending_stream
+        {
+            std::vector<std::byte> buffered;
+            bool connecting{false};
+        };
+
+        struct live_conn
+        {
+            std::shared_ptr<TCPConnection> conn;
+
+            // The remote port this connection was mapped to, for connections we initiated; 0 for
+            // streams we accepted, which belong to no local mapping and so are never closed by one
+            // being released.
+            uint16_t mapped_port{0};
+        };
+
+        Session& _session;
+
+        std::shared_ptr<quic::GNUTLSCreds> _tls_creds;
+        std::shared_ptr<quic::Endpoint> _ep;
+        std::shared_ptr<quic::Connection> _conn;
+
+        // Live TCP connections.  Keyed by an id of our own rather than the stream id: a stream
+        // opened past the peer's stream limit is pending and has no id assigned yet, and those
+        // placeholder ids are not distinct, so keying on them loses connections.
+        std::unordered_map<uint64_t, live_conn> _conns;
+        uint64_t _next_conn_id{0};
+
+        bool _idle_teardown_scheduled{false};
+
+        // Lets deferred callbacks tell that we are gone: some of them fire from libquic destructors,
+        // by which point our members are no longer valid objects.
+        std::shared_ptr<bool> _alive{std::make_shared<bool>(true)};
+
+        void open_connection();
+
+        uint64_t on_stream_opened(quic::Stream& stream);
+        void start_accepted_stream(std::shared_ptr<quic::Stream> stream, std::shared_ptr<pending_stream> pending);
+
+        void adopt(std::shared_ptr<TCPConnection> conn, uint16_t mapped_port);
+        void drop(uint64_t conn_id);
+        void schedule_idle_teardown();
+
+        // Where the accepting side sends a tunnelled connection asking for `port`: our own tun
+        // address, or nullopt if we have no tun device and so cannot accept at all.
+        std::optional<quic::Address> accept_target(uint16_t port) const;
+    };
+
+}  // namespace srouter::session

--- a/src/session_router.cpp
+++ b/src/session_router.cpp
@@ -150,6 +150,83 @@ namespace session::router
         return udp_tunnel{*this, _alive, std::move(ti)};
     }
 
+    tcp_tunnel SessionRouter::establish_tcp(
+        std::string_view remote,
+        uint16_t dest_port,
+        std::function<void(tunnel_info)> on_established,
+        std::function<void(tunnel_failure)> on_failed)
+    {
+        if (srouter::is_valid_sns(remote))
+            throw std::invalid_argument{"establish_tcp requires a network pubkey address, not an ONS/SNS address"};
+
+        srouter::NetworkAddress netaddr;
+        try
+        {
+            netaddr = srouter::NetworkAddress{remote};
+        }
+        catch (const std::exception& e)
+        {
+            throw std::invalid_argument{"Invalid remote address: {}"_format(e.what())};
+        }
+
+        if (dest_port == 0)
+            throw std::invalid_argument{"Invalid remote port: port cannot be 0"};
+
+        auto mapped = context->router->session_endpoint().map_tcp_remote_port(netaddr, dest_port);
+        if (!mapped)
+            return {};
+
+        auto& [local_port, session] = *mapped;
+
+        // No suggested_mtu for TCP: the application does not choose segment sizes, the stack does.
+        tunnel_info ti{
+            .remote = netaddr.to_string(),
+            .remote_port = dest_port,
+            .local_port = local_port,
+            .suggested_mtu = std::nullopt};
+
+        // A remote that turns out not to accept tunnelled TCP is a permanent verdict for this kind
+        // of tunnel, unlike a timeout, so it gets its own failure rather than looking like one.
+        auto check_accepts = [on_established, on_failed, ti](const srouter::session::Session& session) {
+            if (auto accepts = session.remote_accepts_tcp(); accepts.has_value() && !*accepts)
+            {
+                if (on_failed)
+                    on_failed(tunnel_failure::no_tcp);
+                return;
+            }
+            if (on_established)
+                on_established(ti);
+        };
+
+        if (session->is_established())
+        {
+            check_accepts(*session);
+        }
+        else if (session->is_outbound)
+        {
+            if (on_established || on_failed)
+            {
+                auto osession = std::static_pointer_cast<srouter::session::OutboundSession>(session);
+                osession->on_established([check_accepts, on_failed](const srouter::session::OutboundSession& session) {
+                    if (!session.is_established())
+                    {
+                        if (on_failed)
+                            on_failed(session.is_unreachable() ? tunnel_failure::unreachable : tunnel_failure::timeout);
+                        return;
+                    }
+                    check_accepts(session);
+                });
+            }
+        }
+        else
+        {
+            log::warning(
+                logcat, "Unexpected: tunnel session returned a non-established, but also non-outbound session!");
+        }
+
+        return tcp_tunnel{*this, _alive, std::move(ti)};
+    }
+
     udp_tunnel::udp_tunnel(SessionRouter& router, std::weak_ptr<void> alive, tunnel_info info)
         : _router_alive{std::move(alive)}, _router{&router}, _info{std::move(info)}
     {}
@@ -177,6 +254,50 @@ namespace session::router
         _router_alive.reset();
         _router = nullptr;
         _info = {};
+    }
+
+    tcp_tunnel::tcp_tunnel(SessionRouter& router, std::weak_ptr<void> alive, tunnel_info info)
+        : _router_alive{std::move(alive)}, _router{&router}, _info{std::move(info)}
+    {}
+
+    tcp_tunnel& tcp_tunnel::operator=(tcp_tunnel&& other) noexcept
+    {
+        reset();
+        _router_alive = std::exchange(other._router_alive, {});
+        _router = std::exchange(other._router, nullptr);
+        _info = std::exchange(other._info, {});
+        return *this;
+    }
+
+    tcp_tunnel::~tcp_tunnel() { reset(); }
+
+    void tcp_tunnel::reset()
+    {
+        if (!_router)
+            return;
+
+        // A claim can outlive the router it came from, in which case the mapping went away with it.
+        if (auto alive = _router_alive.lock())
+            _router->release_tcp(_info.remote, _info.remote_port);
+
+        _router_alive.reset();
+        _router = nullptr;
+        _info = {};
+    }
+
+    void SessionRouter::release_tcp(const std::string& remote, uint16_t port)
+    {
+        // Reached from ~tcp_tunnel, so this must not throw.  The address came from us in the first
+        // place, so failing to parse it back would be a bug rather than bad input.
+        try
+        {
+            srouter::NetworkAddress netaddr{remote};
+            context->router->session_endpoint().unmap_tcp_remote_port(netaddr, port);
+        }
+        catch (const std::exception& e)
+        {
+            log::error(logcat, "Failed to release TCP tunnel to {}:{}: {}", remote, port, e.what());
+        }
     }
 
     void SessionRouter::release_udp(const std::string& remote, uint16_t port)


### PR DESCRIPTION
This PR adds TCP tunnel support for embedded clients.  It deliberately only implements embedded -> full client tunnels (no embedded-to-embedded, client-to-embedded, or embedded-to-relay).  An embedded device as a TCP recipient *could* be useful, but isn't worth creating an API for until there is an actual use case, and realistically the only thing you would access on a relay is the storage server, which is available over quic (UDP) already.

Also fixes a minor potential issue in the UDP tunnel mapping if the actual tunnel construction raised an exception that would leave a stale entry.

This relies on 

This also includes a minor vaguely related commits:
- changes the default client log level to `*=info, quic=warning` because quic info is too chatty; this also fixes an unexpected behaviour where `level=tcp=debug` in the config file was *ignoring* the default and just setting everything to info.  (Now whatever you specify in the config applies on top of the default).

Requires https://github.com/session-foundation/libquic/pull/15 (for null crypto).