### PR TITLE
RouterID fetching fixes

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1357,7 +1357,7 @@ namespace srouter
             Comment{
                 "Number of local paths that Session Router maintains for both network reachability (i.e. remote",
                 "clients connecting to this instance) and network communication such as looking up",
-                "client lto maintain for network reachability and for general network requests",
+                "client records and updating network state",
                 "",
                 "This value does NOT apply to paths that are built to reach external clients or relays.",
             },

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1331,6 +1331,23 @@ namespace srouter::handlers
             visit(addr, *s);
     }
 
+    std::vector<path::Path*> SessionEndpoint::outbound_session_paths() const
+    {
+        std::vector<path::Path*> paths;
+
+        for (const auto& [remote, session] : _sessions)
+        {
+            if (not session->is_outbound)
+                continue;
+
+            if (auto* outbound = dynamic_cast<session::OutboundSession*>(session.get()))
+                for (auto& path : outbound->active_paths())
+                    paths.push_back(&path);
+        }
+
+        return paths;
+    }
+
     std::optional<std::pair<uint16_t, std::shared_ptr<session::Session>>> SessionEndpoint::map_udp_remote_port(
         const NetworkAddress& remote, uint16_t port)
     {

--- a/src/handlers/session.hpp
+++ b/src/handlers/session.hpp
@@ -338,6 +338,12 @@ namespace srouter
 
             session_tag next_tag();
 
+            // Paths belonging to our outbound sessions.  These are used as extra RouterID fetch
+            // sources when we do not have enough inbound paths of our own; unlike inbound paths,
+            // whose terminals we pick at random, an outbound path's terminal was chosen to reach a
+            // particular remote, so a caller should treat them as the less trustworthy source.
+            std::vector<path::Path*> outbound_session_paths() const;
+
             // UDP port mapping, primarily for embedded clients.  This starts constructing a session
             // to the given remote, starts a UDP listener on an IPv6 localhost (i.e. `[::1]`) random
             // port, and sets up the internal handling so that UDP traffic to that UDP localhost

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -494,10 +494,10 @@ namespace srouter
         auto result_count = std::make_shared<size_t>(0);
         std::vector<path::Path*> selected_paths;
 
-        // In the future, we may want to make paths to selected sources for RID fetching,
-        // but for now just use the first N paths that we already have for simplicity.  If
-        // fetching fails from one, or not all results agree, we probably want to drop that
-        // path anyway.
+        // Our inbound paths are the sources we trust most here: we picked their terminals at
+        // random, for reasons unconnected to whoever we happen to be talking to.
+        std::unordered_set<RouterID> inbound_sources;
+
         for (auto& path : _router.session_endpoint().active_paths())
         {
             if (selected_paths.size() >= RID_SOURCE_COUNT)
@@ -505,26 +505,51 @@ namespace srouter
             auto [itr, inserted] = results->emplace(path.terminal_rid(), std::unordered_set<RouterID>{});
             if (inserted)
             {
+                inbound_sources.insert(path.terminal_rid());
                 selected_paths.push_back(&path);
             }
         }
 
-        if (selected_paths.size() < 2)
+        // Inbound paths are also the utility paths we look up and publish client contacts over, so
+        // having none of them means we are cut off from the network rather than merely short of
+        // sources.  Nothing is gained by rebuilding our view of it from outbound sources alone.
+        if (inbound_sources.empty())
         {
-            log::debug(logcat, "Have fewer than 2 paths, not fetching RouterIDs yet.");
+            log::debug(logcat, "Have no inbound paths, not fetching RouterIDs yet.");
             _router._jq->call_later(100ms, [this] { fetch_rids(); });
             return;
         }
-        else if (selected_paths.size() < RID_SOURCE_COUNT)
+
+        // Short of inbound paths, make the number up from the paths our outbound sessions are
+        // using.  Those terminals were chosen to reach some particular remote rather than at random,
+        // so a peer we are talking to has a hand in who they are; handle_fetched_router_ids makes
+        // them corroborate rather than decide.
+        if (selected_paths.size() < RID_SOURCE_COUNT)
+        {
+            auto extra = _router.session_endpoint().outbound_session_paths();
+            std::ranges::shuffle(extra, srouter::csrng);
+
+            for (auto* path : extra)
+            {
+                if (selected_paths.size() >= RID_SOURCE_COUNT)
+                    break;
+                auto [itr, inserted] = results->emplace(path->terminal_rid(), std::unordered_set<RouterID>{});
+                if (inserted)
+                    selected_paths.push_back(path);
+            }
+        }
+
+        if (selected_paths.size() < RID_SOURCE_COUNT)
             log::info(
                 logcat,
-                "Fetching RIDs from {} sources (want minimum {}, but not enough paths)",
+                "Fetching RouterIDs from {} sources ({} of them inbound); wanted {}, but have no more paths to ask",
                 selected_paths.size(),
+                inbound_sources.size(),
                 RID_SOURCE_COUNT);
 
         for (auto* path : selected_paths)
         {
-            auto result_cb = [this, results, result_count, source = path->terminal_rid()](auto resp) {
+            auto result_cb = [this, results, result_count, inbound_sources, source = path->terminal_rid()](auto resp) {
                 (*result_count)++;
                 if (not resp.ok())
                 {
@@ -558,47 +583,97 @@ namespace srouter
                 }
                 if (*result_count == results->size())
                 {
-                    // FIXME: call again sooner if enough failed
-                    _router._jq->call_later(FETCH_INTERVAL, [this] { fetch_rids(); });
-                    handle_fetched_router_ids(*results);
+                    // Whatever happens while applying the results, the next round has to get
+                    // scheduled: dropping it would stop us fetching RouterIDs for good.
+                    bool conclusive = false;
+                    try
+                    {
+                        conclusive = handle_fetched_router_ids(*results, inbound_sources);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        log::error(logcat, "Error applying fetched RouterIDs: {}", e.what());
+                    }
+
+                    _router._jq->call_later(
+                        conclusive ? FETCH_INTERVAL : FETCH_RETRY_INTERVAL, [this] { fetch_rids(); });
                 }
             };
             path->send_path_control_message("fetch_rids"sv, {}, std::move(result_cb));
         }
     }
 
-    void NodeDB::handle_fetched_router_ids(const std::unordered_map<RouterID, std::unordered_set<RouterID>>& results)
+    bool NodeDB::handle_fetched_router_ids(
+        const std::unordered_map<RouterID, std::unordered_set<RouterID>>& results,
+        const std::unordered_set<RouterID>& inbound_sources)
     {
         assert(_router.loop().inside());
+
+        const size_t asked = results.size();
+
+        // A RouterID is accepted when a strict majority of the sources we asked affirm it -- 3 of 5,
+        // 3 of 4, 2 of 3, and so on down -- and that majority has to include one of our own inbound
+        // sources.  An outbound path's terminal is reached on behalf of some remote, so left to
+        // themselves those sources could walk us onto a different view of the network; where every
+        // source is inbound the requirement costs nothing, as any majority contains one.
+        //
+        // A source that failed, timed out or sent us nonsense simply affirms nothing, which is the
+        // same to us as one that answered without it.
+        const size_t needed = asked / 2 + 1;
+
         std::unordered_set<RouterID> accepted{};
 
-        auto itr = results.begin();
-        while (itr != results.end())
+        for (const auto& [source, rids] : results)
         {
-            for (const auto& rid : itr->second)
+            for (const auto& rid : rids)
             {
-                size_t count{0};
-                auto cur_itr = results.begin();
-                while (cur_itr != results.end())
+                if (accepted.contains(rid))
+                    continue;
+
+                size_t agree = 0;
+                bool inbound_agrees = false;
+                for (const auto& [other, other_rids] : results)
+                    if (other_rids.contains(rid))
+                    {
+                        agree++;
+                        if (inbound_sources.contains(other))
+                            inbound_agrees = true;
+                    }
+
+                if (agree < needed)
+                    continue;
+
+                if (not inbound_agrees)
                 {
-                    if (cur_itr->second.contains(rid))
-                        count++;
-                    cur_itr++;
+                    log::info(
+                        logcat,
+                        "{} sources know RouterID {}, but none of them is one of ours; not accepting it",
+                        agree,
+                        rid);
+                    continue;
                 }
-                // FIXME: better than "half-rounded-up agree"
-                if (count > (results.size() / 2))
-                    accepted.insert(rid);
-                else
-                    log::info(logcat, "Received a RouterID that not enough nodes agree is correct: {}", rid);
+
+                accepted.insert(rid);
             }
-            itr++;
         }
 
-        known_rids.clear();
-        for (const auto& rid : accepted)
-            known_rids.insert(rid);
+        // Whether the sources disagreed or simply did not answer, the outcome is the same: we have
+        // no consensus to act on.  We got the list we already have from somewhere, and had reason to
+        // trust it, so it stands until a consensus replaces it.
+        if (accepted.empty())
+        {
+            log::warning(
+                logcat,
+                "No consensus from {} RouterID sources; keeping the {} RouterIDs we already have",
+                asked,
+                known_rids.size());
+            return false;
+        }
+
+        known_rids = std::move(accepted);
 
         fetch_rcs();
+        return true;
     }
 
     void NodeDB::start()

--- a/src/nodedb.cpp
+++ b/src/nodedb.cpp
@@ -628,6 +628,10 @@ namespace srouter
 
     void NodeDB::on_bootstrap_done(bool success)
     {
+        // This attempt is over either way; without clearing it the guard in purge_rcs() stays shut
+        // for the life of the process, and a client that loses its relays can never bootstrap again.
+        _bootstrap_running = false;
+
         if (success)
         {
             log::debug(logcat, "Bootstrap attempt completed successfully");

--- a/src/nodedb.hpp
+++ b/src/nodedb.hpp
@@ -24,6 +24,10 @@ namespace srouter
     class Router;
 
     inline constexpr auto FETCH_INTERVAL{5min};
+
+    // Used instead of FETCH_INTERVAL when a fetch round could not settle anything, so that a
+    // client with flaky paths retries promptly rather than sitting on stale RouterIDs.
+    inline constexpr auto FETCH_RETRY_INTERVAL{30s};
     inline constexpr auto PURGE_INTERVAL{5min};
 
     // fallback to bootstrap if we have less than this many RCs
@@ -258,7 +262,12 @@ namespace srouter
         /// remove any stored RCs matching the given predicate
         void remove_rcs_if(const std::function<bool(const RelayContact&)>& remove);
 
-        void handle_fetched_router_ids(const std::unordered_map<RouterID, std::unordered_set<RouterID>>& results);
+        // Applies a completed round of RID fetches.  Returns false if the round produced no
+        // consensus, whether from disagreement or from sources that did not answer, in which case
+        // what we already know is left alone.
+        bool handle_fetched_router_ids(
+            const std::unordered_map<RouterID, std::unordered_set<RouterID>>& results,
+            const std::unordered_set<RouterID>& inbound_sources);
 
         // Called on the disk thread to store/update/erase 0rtt tickets for a router id.
         void save_0rtt(const RouterID& rid);


### PR DESCRIPTION
- Fixes a bug where the "we are bootstrapping" flag was never reset, and so if you ran out of RouterIDs for some reason, you just stayed there forever (until restarting) rather than re-bootstrapping.
- Fixes some broken cases and suboptimal choices in the RouterID fetching logic:
  - our "target" sources for fetching new RID lists was larger than the default number of inbound/utility paths, so clients would *always* get log messages about fetch size reduction due to not have enough sources.
  - having only one inbound path would never re-fetch and would sit on a 100ms loop re-trying
  - we treated fetch failure as disagreement, and so if the client failed to fetch enough RIDs to find consensus, it threw out the entire RID list.  This would generally cause a spurious rebootstrapping (and without the first fix above, a permanent network disconnection).

This PR fixes the RouterID fetching logic by somewhat reworking it:
- if we don't have enough inbound paths for the target number of RID sources, we add outbound paths to our query paths.  We still require consensus, but now *also* require that at least one of the nodes making up such a consensus is an inbound path (so that we aren't purely trusting outbound paths that a client contact could direct us towards).
- when we fail to achieve consensus either because of disagreement or failed request, we know just keep our previous RouterID list rather than throwing out the entire thing.