### PR TITLE
Stop rebuilding paths to a relay we know is unreachable

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -421,18 +421,14 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                   oxen_repo=[],
                   cmake_extra='-DBUILD_STATIC_DEPS=ON -DBUILD_SHARED_LIBS=OFF -DSTATIC_LINK=ON'),
 
-  debian_pipeline('Debian 11/bullseye',
-                  docker_base + 'debian-bullseye',
-                  deps=default_deps(remove='libcli11-dev')),
-
   // Static builds (uploaded to builds.lokinet.dev).  In general:
   // - armhf and arm64 build on the oldest debian distro we support.  Technically there is some
   //   arm64 ubuntu support, but the arm linux ecosystem seems to much more built on top of debian
   //   rather than ubuntu.
   // - amd64 we build on the oldest Debian *or* Ubuntu distro, so that it should work on that or
   //   anything newer.
-  debian_pipeline('Static armhf (Debian 11/bullseye)',
-                  docker_base + 'debian-bullseye/arm32v7',
+  debian_pipeline('Static armhf (Debian 12/bookworm)',
+                  docker_base + 'debian-bookworm/arm32v7',
                   arch='arm64',
                   deps=static_deps,
                   tests=false,
@@ -445,8 +441,8 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                     'UPLOAD_OS=linux-armhf ./contrib/ci/drone-static-upload.sh',
                   ],
                   jobs=4),
-  debian_pipeline('Static arm64 (Debian 11/bullseye)',
-                  docker_base + 'debian-bullseye',
+  debian_pipeline('Static arm64 (Debian 12/bookworm)',
+                  docker_base + 'debian-bookworm',
                   arch='arm64',
                   deps=static_deps,
                   tests=false,
@@ -459,8 +455,8 @@ local docs_pipeline(name, image, extra_cmds=[], allow_fail=false) = {
                     'UPLOAD_OS=linux-armhf ./contrib/ci/drone-static-upload.sh',
                   ],
                   jobs=4),
-  debian_pipeline('Static AMD64 (Debian 11/bullseye)',
-                  docker_base + 'debian-bullseye',
+  debian_pipeline('Static AMD64 (Ubuntu jammy)',
+                  docker_base + 'ubuntu-jammy',
                   deps=static_deps,
                   lto=true,
                   tests=false,

--- a/src/handlers/session.cpp
+++ b/src/handlers/session.cpp
@@ -1296,10 +1296,15 @@ namespace srouter::handlers
                         s = router._jq->make_shared<session::OutboundRelaySession>(
                             remote, *this, tag, std::move(on_attempted), timeout);
 
-                    // A relay session resolves its RC during construction, so if the relay has no
+                    // A relay session looks its RC up during construction, so if the relay has no
                     // RC we already know the session can never establish.  Don't register it: the
                     // caller gets nullptr, and a later attempt builds a fresh session that looks
                     // the RC up again rather than reusing this verdict.
+                    //
+                    // Only catches a lookup that answered inline, which is the usual case but not
+                    // the one that hurts: before the first RC fetch completes NodeDB::lookup_rc
+                    // queues the callback, and the verdict lands after we have registered the
+                    // session.  OutboundSession::tick closes it when that happens.
                     if (s->is_unreachable())
                         return std::shared_ptr<session::Session>{nullptr};
 

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -1082,6 +1082,22 @@ namespace srouter::session
         if (_is_closed)
             return;
 
+        // No relay contact for the remote means no path can ever pivot through it, so there is
+        // nothing to build and re-attempting only burns ticks.
+        //
+        // Such a session is normally discarded at construction -- SessionEndpoint::make_session
+        // checks is_unreachable() before registering it -- but that only catches a lookup that
+        // answered inline.  Until the first RC fetch completes, NodeDB::lookup_rc queues the
+        // callback rather than answering, so the verdict arrives after we have been registered and
+        // there is nobody left to discard us.  Close here instead, which is the same thing the
+        // constructor-time check does, just later.
+        if (_unreachable)
+        {
+            log::debug(logcat, "{} is unreachable; closing session rather than rebuilding", _remote);
+            _parent.close_session(_inbound_tag, false);
+            return;
+        }
+
         close_old_paths(now);
         path::PathHandler::tick(now);
         fire_waiting();


### PR DESCRIPTION
A session to a relay with no RC cannot ever establish -- no path can pivot through a router we hold no contact for -- and SessionEndpoint:: make_session already refuses to register one, discarding it so that a later attempt looks the RC up afresh.

That check reads is_unreachable() as soon as the constructor returns, which only works when the lookup answered inline.  It usually does.  The case where it does not is startup: until the first RC fetch completes, NodeDB::lookup_rc queues the callback instead of answering, so the constructor returns with the session still looking viable, it gets registered, and the verdict arrives a moment later with nobody left to act on it.

From there the session sat in the table re-attempting a path it had already concluded was impossible, once every 250ms, until it expired on SESSION_TIMEOUT -- around 120 attempts and 360 warnings over 30 seconds, for a remote whose caller had been told "unreachable" 29 seconds earlier.

Observed against mainnet, where it is not rare: storage servers still on 2.11.0 predate session-router and so never publish an RC.  They are roughly a sixth of the network, they remain perfectly good storage nodes, and a client picking swarm members at random lands on one often.

So close in tick() when the flag is set, which is what the constructor-time check does, only later.